### PR TITLE
feat: Windows module toolchain support via Perl Config.pm

### DIFF
--- a/internal/perl/build_enhanced_test.go
+++ b/internal/perl/build_enhanced_test.go
@@ -106,7 +106,7 @@ func TestDependencyChecker(t *testing.T) {
 	// Check that basic tools are detected (platform-specific)
 	basicTools := []string{"make", "tar", "gzip"}
 	if runtime.GOOS == "windows" {
-		basicTools = []string{"nmake", "cl"}
+		basicTools = []string{"gmake", "gcc"}
 	}
 	for _, tool := range basicTools {
 		found := false

--- a/internal/perl/dependencies.go
+++ b/internal/perl/dependencies.go
@@ -103,10 +103,10 @@ func (dc *DependencyChecker) getRequiredDependencies() []dependency {
 			dependency{name: "bzip2", command: "bzip2"},
 		)
 	case "windows":
-		// Windows has different requirements
+		// Strawberry Perl includes GNU toolchain (gmake, gcc)
 		deps = []dependency{
-			{name: "nmake", command: "nmake"},
-			{name: "cl", command: "cl"},
+			{name: "gmake", command: "gmake"},
+			{name: "gcc", command: "gcc"},
 		}
 	}
 
@@ -208,8 +208,8 @@ func (dc *DependencyChecker) getInstallHint(dep string) string {
 			"xz":       "apt-get install xz-utils (Debian/Ubuntu) or yum install xz (RHEL/CentOS)",
 		},
 		"windows": {
-			"nmake": "Install Visual Studio or Build Tools for Visual Studio",
-			"cl":    "Install Visual Studio or Build Tools for Visual Studio",
+			"gmake": "Install Strawberry Perl (https://strawberryperl.com) which includes gmake",
+			"gcc":   "Install Strawberry Perl (https://strawberryperl.com) which includes gcc",
 			"git":   "Download from https://git-scm.com/download/win",
 			"wget":  "Install from chocolatey: choco install wget",
 		},
@@ -278,9 +278,8 @@ func GetPlatformSpecificNotes() string {
 	case "windows":
 		return strings.Join([]string{
 			"Windows Build Notes:",
-			"- Visual Studio or Build Tools for Visual Studio required",
-			"- Consider using WSL2 for a more Unix-like build environment",
-			"- Native Windows builds may have limited functionality",
+			"- Strawberry Perl (https://strawberryperl.com) includes gmake and gcc",
+			"- Alternatively, use WSL2 for a Unix-like build environment",
 		}, "\n")
 
 	default:

--- a/internal/pm/modules/builder.go
+++ b/internal/pm/modules/builder.go
@@ -281,6 +281,12 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 	log.Debugf("Detected build system: %s", buildSystem)
 	updateStage(StagePrepare, fmt.Sprintf("Detected build system: %s", buildSystem), 0.5)
 
+	// Detect the correct make command for this Perl installation
+	makeCmd, err := detectMakeCommand(options.PerlPath)
+	if err != nil {
+		log.Warnf("Could not detect make command, falling back to 'make': %v", err)
+	}
+
 	// Create build script based on the detected build system
 	updateStage(StageCreateBuildScript, "Creating build script", 0.0)
 
@@ -314,7 +320,7 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 			}
 
 			// Now the ./Build script should exist
-			installCmd = []string{"./Build", "install"}
+			installCmd = buildPLCommand(options.PerlPath, "install")
 			if options.Force {
 				installCmd = append(installCmd, "--force")
 			}
@@ -349,7 +355,7 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 			}
 
 			// Now make should work
-			installCmd = []string{"make", "install"}
+			installCmd = []string{makeCmd, "install"}
 			if options.Force {
 				installCmd = append(installCmd, "FORCE=1")
 			}
@@ -360,7 +366,7 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 			updateStage(StageCreateBuildScript, "Using existing Makefile", 0.5)
 
 			// Use make directly
-			installCmd = []string{"make", "install"}
+			installCmd = []string{makeCmd, "install"}
 			if options.Force {
 				installCmd = append(installCmd, "FORCE=1")
 			}
@@ -381,7 +387,7 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 	switch buildSystem {
 	case "Build.PL":
 		// Build with Module::Build
-		cmd := []string{"./Build"}
+		cmd := buildPLCommand(options.PerlPath)
 		if options.Verbose {
 			cmd = append(cmd, "--verbose")
 		}
@@ -400,7 +406,7 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 
 	case "Makefile.PL", "Makefile":
 		// Build with make
-		cmd := []string{"make"}
+		cmd := []string{makeCmd}
 
 		// Determine number of parallel jobs (for make -j)
 		jobs := runtime.NumCPU()
@@ -428,12 +434,12 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 		var testCmd []string
 		switch buildSystem {
 		case "Build.PL":
-			testCmd = []string{"./Build", "test"}
+			testCmd = buildPLCommand(options.PerlPath, "test")
 			if options.Verbose {
 				testCmd = append(testCmd, "--verbose")
 			}
 		case "Makefile.PL", "Makefile":
-			testCmd = []string{"make", "test"}
+			testCmd = []string{makeCmd, "test"}
 		}
 
 		// Add any user-specified test arguments
@@ -528,6 +534,16 @@ func detectMakeCommand(perlPath string) (string, error) {
 		return "make", nil
 	}
 	return cmd, nil
+}
+
+// buildPLCommand returns the command to run a Module::Build script.
+// On Unix, ./Build is directly executable via shebang.
+// On Windows, it must be invoked through the Perl interpreter.
+func buildPLCommand(perlPath string, args ...string) []string {
+	if runtime.GOOS == "windows" {
+		return append([]string{perlPath, "Build"}, args...)
+	}
+	return append([]string{"./Build"}, args...)
 }
 
 // runCommandWithEnv runs a command in the specified directory with custom environment variables

--- a/internal/pm/modules/builder.go
+++ b/internal/pm/modules/builder.go
@@ -515,6 +515,21 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 	return result, nil
 }
 
+// detectMakeCommand queries the active Perl for its configured make command.
+// Perl's Config.pm knows which make to use for the current installation
+// (e.g., "make" on Unix, "gmake" on Strawberry Perl, "nmake" on MSVC Perl).
+func detectMakeCommand(perlPath string) (string, error) {
+	out, err := exec.Command(perlPath, "-MConfig", "-e", `print $Config{make}`).Output()
+	if err != nil {
+		return "make", err
+	}
+	cmd := strings.TrimSpace(string(out))
+	if cmd == "" {
+		return "make", nil
+	}
+	return cmd, nil
+}
+
 // runCommandWithEnv runs a command in the specified directory with custom environment variables
 func runCommandWithEnv(dir string, command []string, ctx context.Context, envVars map[string]string) (string, error) {
 	if len(command) == 0 {

--- a/internal/pm/modules/builder.go
+++ b/internal/pm/modules/builder.go
@@ -284,7 +284,10 @@ func buildAndInstallModule(options *ModuleBuildOptions) (*ModuleBuildResult, err
 	// Detect the correct make command for this Perl installation
 	makeCmd, err := detectMakeCommand(options.PerlPath)
 	if err != nil {
-		log.Warnf("Could not detect make command, falling back to 'make': %v", err)
+		if runtime.GOOS == "windows" {
+			makeCmd = "gmake"
+		}
+		log.Warnf("Could not detect make command, falling back to %q: %v", makeCmd, err)
 	}
 
 	// Create build script based on the detected build system

--- a/internal/pm/modules/builder_test.go
+++ b/internal/pm/modules/builder_test.go
@@ -5,6 +5,7 @@ package modules
 
 import (
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -46,5 +47,47 @@ func TestDetectMakeCommand_Fallback(t *testing.T) {
 
 	if cmd != "make" {
 		t.Errorf("detectMakeCommand should fall back to 'make', got %q", cmd)
+	}
+}
+
+// TestBuildPLCommand verifies that buildPLCommand returns the correct command
+// for the current platform with no extra arguments.
+func TestBuildPLCommand(t *testing.T) {
+	cmd := buildPLCommand("/usr/bin/perl")
+	if runtime.GOOS == "windows" {
+		if len(cmd) != 2 || cmd[0] != "/usr/bin/perl" || cmd[1] != "Build" {
+			t.Errorf("Expected [/usr/bin/perl Build], got %v", cmd)
+		}
+	} else {
+		if len(cmd) != 1 || cmd[0] != "./Build" {
+			t.Errorf("Expected [./Build], got %v", cmd)
+		}
+	}
+}
+
+// TestBuildPLCommand_WithArgs verifies that buildPLCommand correctly threads
+// extra arguments after the base command on both platforms.
+func TestBuildPLCommand_WithArgs(t *testing.T) {
+	cmd := buildPLCommand("/usr/bin/perl", "install", "--verbose")
+	if runtime.GOOS == "windows" {
+		expected := []string{"/usr/bin/perl", "Build", "install", "--verbose"}
+		if len(cmd) != 4 {
+			t.Fatalf("Expected 4 elements, got %d: %v", len(cmd), cmd)
+		}
+		for i, v := range expected {
+			if cmd[i] != v {
+				t.Errorf("cmd[%d] = %q, want %q", i, cmd[i], v)
+			}
+		}
+	} else {
+		expected := []string{"./Build", "install", "--verbose"}
+		if len(cmd) != 3 {
+			t.Fatalf("Expected 3 elements, got %d: %v", len(cmd), cmd)
+		}
+		for i, v := range expected {
+			if cmd[i] != v {
+				t.Errorf("cmd[%d] = %q, want %q", i, cmd[i], v)
+			}
+		}
 	}
 }

--- a/internal/pm/modules/builder_test.go
+++ b/internal/pm/modules/builder_test.go
@@ -1,0 +1,50 @@
+// ABOUTME: Tests for the module builder functionality
+// ABOUTME: Tests detectMakeCommand and related builder helper functions
+
+package modules
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"tamarou.com/pvm/internal/perl"
+)
+
+// TestDetectMakeCommand verifies that detectMakeCommand returns a non-empty
+// make command when queried against a real Perl installation.
+func TestDetectMakeCommand(t *testing.T) {
+	systemPerl, err := perl.DetectSystemPerl()
+	if err != nil {
+		t.Skipf("No system Perl available for testing: %v", err)
+	}
+
+	// Verify the perl binary is actually executable before proceeding
+	if _, err := exec.LookPath(systemPerl.Path); err != nil {
+		t.Skipf("System Perl binary not executable: %v", err)
+	}
+
+	cmd, err := detectMakeCommand(systemPerl.Path)
+	if err != nil {
+		t.Fatalf("detectMakeCommand returned unexpected error: %v", err)
+	}
+
+	if strings.TrimSpace(cmd) == "" {
+		t.Error("detectMakeCommand returned an empty make command")
+	}
+
+	t.Logf("detectMakeCommand returned: %q", cmd)
+}
+
+// TestDetectMakeCommand_Fallback verifies that detectMakeCommand falls back to
+// "make" and returns an error when given a nonexistent Perl path.
+func TestDetectMakeCommand_Fallback(t *testing.T) {
+	cmd, err := detectMakeCommand("/nonexistent/path/to/perl")
+	if err == nil {
+		t.Error("detectMakeCommand should return an error for a nonexistent perl path")
+	}
+
+	if cmd != "make" {
+		t.Errorf("detectMakeCommand should fall back to 'make', got %q", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

- Make `pvm module install` work with Strawberry Perl on Windows
- Query Perl's `Config.pm` for the correct make command instead of hardcoding `"make"`
- Fix `./Build` invocation on Windows (must use `perl Build` since Windows lacks shebang handling)
- Update dependency checker to look for Strawberry Perl's GNU toolchain (gmake, gcc)

## Design

See [docs/plans/2026-03-24-windows-module-toolchain.md](docs/plans/2026-03-24-windows-module-toolchain.md)

Core approach: `perl -MConfig -e "print $Config{make}"` returns the correct make command for any Perl distribution — `make` on Unix, `gmake` on Strawberry, `nmake` on MSVC.

## Changes

| Component | Files | Description |
|-----------|-------|-------------|
| detectMakeCommand | `builder.go`, `builder_test.go` | New function querying Perl's Config.pm |
| Build command replacement | `builder.go` | 4 hardcoded `"make"` → detected command, 3 `"./Build"` → `buildPLCommand()` |
| Dependency checker | `dependencies.go`, `build_enhanced_test.go` | Windows: gmake/gcc instead of nmake/cl |
| Windows fallback | `builder.go` | Falls back to `gmake` on Windows, `make` on Unix |

## Stats
- 4 files changed, ~80 insertions, ~20 deletions

## Related Issues
- Closes #414, #415, #416
- Milestone: [Windows Module Toolchain](https://github.com/perigrin/pvm/milestone/9)

## Test plan
- [x] All tests pass on Linux (`make test`)
- [ ] Windows CI passes
- [ ] macOS CI passes