### PR TITLE
docs: add editor setup guide, install script, and type checking cookbook

### DIFF
--- a/getting-started.html
+++ b/getting-started.html
@@ -41,23 +41,12 @@
 
     <section>
       <h2>Install PVM</h2>
-      <p>Download the binary for your platform and place it somewhere on your <code>PATH</code>.</p>
+      <p>The install script detects your platform, downloads the latest release, and places the binary in <code>~/.local/bin</code>.</p>
 
-      <h3>Linux (AMD64)</h3>
-      <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-linux-amd64.tar.gz
-tar -xzf pvm-linux-amd64.tar.gz
-sudo mv pvm /usr/local/bin/pvm</code></pre>
+      <pre><code>curl -fsSL https://pvm.tools/install.sh | sh</code></pre>
 
-      <h3>Linux (ARM64)</h3>
-      <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-linux-arm64.tar.gz
-tar -xzf pvm-linux-arm64.tar.gz
-sudo mv pvm /usr/local/bin/pvm</code></pre>
-
-      <h3>macOS (Apple Silicon)</h3>
-      <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-darwin-arm64.tar.gz
-tar -xzf pvm-darwin-arm64.tar.gz
-chmod +x pvm
-sudo mv pvm /usr/local/bin/pvm</code></pre>
+      <p>Set <code>PVM_INSTALL_DIR</code> to install somewhere else:</p>
+      <pre><code>PVM_INSTALL_DIR=/usr/local/bin curl -fsSL https://pvm.tools/install.sh | sh</code></pre>
 
       <h3>Build from source (Go 1.24+)</h3>
       <pre><code>git clone https://github.com/perigrin/pvm.git &amp;&amp; cd pvm &amp;&amp; make</code></pre>

--- a/guides/editor-setup.html
+++ b/guides/editor-setup.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="color-scheme" content="light dark">
+  <meta name="description" content="Set up PSC in your editor — copy-paste configurations for Vim, Neovim, VS Code, Emacs, Sublime Text, and Helix.">
+  <meta property="og:title" content="Editor Setup — PVM">
+  <meta property="og:description" content="Set up PSC in your editor — copy-paste configurations for Vim, Neovim, VS Code, Emacs, Sublime Text, and Helix.">
+  <meta property="og:url" content="https://pvm.tools/guides/editor-setup.html">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary">
+  <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,700;1,400&family=IBM+Plex+Mono:wght@400;500&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../assets/style.css">
+  <title>Editor Setup — PVM</title>
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="/" class="site-name">PVM</a>
+      <button class="nav-toggle" aria-expanded="false" aria-label="Menu">&#9776;</button>
+      <ul class="nav-links">
+        <li><a href="../getting-started.html">Docs</a></li>
+        <li><a href="../reference/pvm.html">Reference</a></li>
+        <li><a href="../guides/inline-scripts.html">Guides</a></li>
+        <li><a href="../papers/index.html">Papers</a></li>
+        <li><a href="../why-pvm.html">Why PVM</a></li>
+        <li><a href="https://github.com/perigrin/pvm">GitHub</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main>
+    <section>
+      <h1>Editor Setup</h1>
+      <p>PSC produces diagnostics in the standard <code>filename:line:col: severity: message [code]</code> format. Every editor that can parse compiler output can run PSC. This page gives copy-paste configurations for the most common editors.</p>
+      <p>Each configuration runs <code>psc check</code> on the current file and displays the results as inline diagnostics. For background on what PSC catches, see the <a href="type-checking.html">Type Checking guide</a>.</p>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>Vim</h2>
+
+      <h3>ALE (recommended)</h3>
+      <p><a href="https://github.com/dense-analysis/ale">ALE</a> runs linters asynchronously and displays results as you edit. Add to your <code>.vimrc</code>:</p>
+      <pre><code>" Run PSC on Perl files
+let g:ale_linters = { 'perl': ['psc'] }
+
+" Define PSC as a linter
+call ale#linter#Define('perl', {
+\   'name': 'psc',
+\   'executable': 'psc',
+\   'command': 'psc check %s',
+\   'callback': 'ale#handlers#gcc#HandleGCCFormat',
+\ })</code></pre>
+      <p>Save a Perl file and diagnostics appear in the sign column.</p>
+
+      <h3>Syntastic</h3>
+      <p><a href="https://github.com/vim-syntastic/syntastic">Syntastic</a> checks files on save. Add to your <code>.vimrc</code>:</p>
+      <pre><code>let g:syntastic_perl_checkers = ['psc']
+let g:syntastic_perl_psc_exec = 'psc'
+let g:syntastic_perl_psc_args = 'check'</code></pre>
+
+      <h3>Compiler plugin (no plugin required)</h3>
+      <p>Vim's built-in <code>:compiler</code> mechanism works with PSC's output format. Create <code>~/.vim/compiler/psc.vim</code>:</p>
+      <pre><code>CompilerSet makeprg=psc\ check\ %
+CompilerSet errorformat=%f:%l:%c:\ %t%*[^:]:\ %m</code></pre>
+      <p>Then run <code>:compiler psc</code> and <code>:make</code> to populate the quickfix list.</p>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>Neovim</h2>
+
+      <h3>nvim-lint (recommended)</h3>
+      <p><a href="https://github.com/mfussenegger/nvim-lint">nvim-lint</a> runs linters asynchronously. Add to your Lua config:</p>
+      <pre><code>require('lint').linters.psc = {
+  cmd = 'psc',
+  args = { 'check' },
+  stdin = false,
+  append_fname = true,
+  stream = 'stderr',
+  parser = require('lint.parser').from_errorformat(
+    '%f:%l:%c: %trror: %m,%f:%l:%c: %tarning: %m,%f:%l:%c: %tint: %m',
+    { source = 'psc' }
+  ),
+}
+
+require('lint').linters_by_ft = {
+  perl = { 'psc' },
+}
+
+-- Lint on save
+vim.api.nvim_create_autocmd({ 'BufWritePost' }, {
+  callback = function() require('lint').try_lint() end,
+})</code></pre>
+
+      <h3>efm-langserver</h3>
+      <p><a href="https://github.com/mattn/efm-langserver">efm-langserver</a> wraps command-line tools as LSP servers. Add to your efm config (<code>~/.config/efm-langserver/config.yaml</code>):</p>
+      <pre><code>languages:
+  perl:
+    - lint-command: 'psc check ${INPUT}'
+      lint-stdin: false
+      lint-formats:
+        - '%f:%l:%c: %trror: %m'
+        - '%f:%l:%c: %tarning: %m'
+        - '%f:%l:%c: %tint: %m'</code></pre>
+      <p>Then register efm as a language server in your Neovim config:</p>
+      <pre><code>require('lspconfig').efm.setup({
+  filetypes = { 'perl' },
+  init_options = { documentFormatting = false },
+})</code></pre>
+
+      <h3>Compiler command (no plugin required)</h3>
+      <pre><code>vim.api.nvim_create_autocmd('FileType', {
+  pattern = 'perl',
+  callback = function()
+    vim.bo.makeprg = 'psc check %'
+    vim.bo.errorformat = '%f:%l:%c: %trror: %m,%f:%l:%c: %tint: %m'
+  end,
+})</code></pre>
+      <p>Run <code>:make</code> and results appear in the quickfix list. Jump between them with <code>:cnext</code> and <code>:cprev</code>.</p>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>VS Code</h2>
+
+      <h3>Tasks + Problem Matcher</h3>
+      <p>VS Code can run PSC as a build task and parse its output into the Problems panel. Add to <code>.vscode/tasks.json</code>:</p>
+      <pre><code>{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "PSC: Check current file",
+      "type": "shell",
+      "command": "psc",
+      "args": ["check", "${file}"],
+      "group": "build",
+      "problemMatcher": {
+        "owner": "psc",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s+(error|warning|hint):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    },
+    {
+      "label": "PSC: Check project",
+      "type": "shell",
+      "command": "psc",
+      "args": ["check", "lib/"],
+      "group": "build",
+      "problemMatcher": {
+        "owner": "psc",
+        "fileLocation": ["relative", "${workspaceFolder}"],
+        "pattern": {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s+(error|warning|hint):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      }
+    }
+  ]
+}</code></pre>
+      <p>Run with <kbd>Ctrl+Shift+B</kbd> (or <kbd>Cmd+Shift+B</kbd> on macOS) and select the task. Diagnostics appear in the Problems panel with clickable file locations.</p>
+
+      <h3>Run on Save (optional)</h3>
+      <p>Install the <a href="https://marketplace.visualstudio.com/items?itemName=emeraldwalk.RunOnSave">Run on Save</a> extension and add to <code>.vscode/settings.json</code>:</p>
+      <pre><code>{
+  "emeraldwalk.runonsave": {
+    "commands": [
+      {
+        "match": "\\.(pl|pm|t)$",
+        "cmd": "psc check ${file}"
+      }
+    ]
+  }
+}</code></pre>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>Emacs</h2>
+
+      <h3>Flycheck (recommended)</h3>
+      <p><a href="https://www.flycheck.org/">Flycheck</a> displays inline diagnostics as you edit. Add to your init file:</p>
+      <pre><code>(require 'flycheck)
+
+(flycheck-define-checker perl-psc
+  "A Perl type checker using PSC."
+  :command ("psc" "check" source)
+  :error-patterns
+  ((error line-start (file-name) ":" line ":" column ": error: " (message) line-end)
+   (warning line-start (file-name) ":" line ":" column ": warning: " (message) line-end)
+   (info line-start (file-name) ":" line ":" column ": hint: " (message) line-end))
+  :modes (perl-mode cperl-mode))
+
+(add-to-list 'flycheck-checkers 'perl-psc)</code></pre>
+
+      <h3>Flymake (built-in)</h3>
+      <p>Flymake ships with Emacs 26+. No external package required:</p>
+      <pre><code>(defun flymake-psc-init ()
+  "Set up Flymake for PSC."
+  (let ((temp-file (flymake-proc-init-create-temp-buffer-copy
+                    'flymake-proc-create-temp-inplace)))
+    (list "psc" (list "check" temp-file))))
+
+(add-to-list 'flymake-proc-allowed-file-name-masks
+             '("\\.p[lm]\\'" flymake-psc-init))
+
+(add-hook 'perl-mode-hook #'flymake-mode)
+(add-hook 'cperl-mode-hook #'flymake-mode)</code></pre>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>Sublime Text</h2>
+
+      <h3>SublimeLinter</h3>
+      <p>Install <a href="https://github.com/SublimeLinter/SublimeLinter">SublimeLinter</a> via Package Control, then add to your SublimeLinter settings (<code>Preferences &gt; Package Settings &gt; SublimeLinter &gt; Settings</code>):</p>
+      <pre><code>{
+  "linters": {
+    "psc": {
+      "cmd": "psc check ${file}",
+      "regex": "^(?P&lt;file&gt;.+):(?P&lt;line&gt;\\d+):(?P&lt;col&gt;\\d+): (?P&lt;error&gt;error|warning|hint): (?P&lt;message&gt;.+)$",
+      "selector": "source.perl"
+    }
+  }
+}</code></pre>
+
+      <h3>Build System (no plugin required)</h3>
+      <p>Create a build system via <code>Tools &gt; Build System &gt; New Build System</code>:</p>
+      <pre><code>{
+  "cmd": ["psc", "check", "$file"],
+  "file_regex": "^(.+):(\\d+):(\\d+): (error|warning|hint): (.+)$",
+  "selector": "source.perl"
+}</code></pre>
+      <p>Save as <code>PSC.sublime-build</code>. Run with <kbd>Ctrl+B</kbd> (or <kbd>Cmd+B</kbd> on macOS) and double-click results to jump to the source.</p>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>Helix</h2>
+      <p>Helix supports external formatters and language servers. Until PSC's built-in LSP server ships, use efm-langserver as a bridge. Add to <code>~/.config/helix/languages.toml</code>:</p>
+      <pre><code>[[language]]
+name = "perl"
+language-servers = ["efm-lsp-perl"]
+
+[language-server.efm-lsp-perl]
+command = "efm-langserver"</code></pre>
+      <p>Then configure efm-langserver to run PSC as described in the <a href="#neovim">Neovim efm-langserver section</a> above.</p>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>CI / command line</h2>
+      <p>PSC works in any pipeline that can run a binary. It exits 0 on success and non-zero when diagnostics are found:</p>
+      <pre><code># Check a single file
+psc check lib/MyModule.pm
+
+# Check an entire project
+psc check lib/
+
+# Use in a Makefile
+check:
+&#9;psc check lib/ t/</code></pre>
+      <p>In GitHub Actions:</p>
+      <pre><code>- name: Type-check Perl
+  run: psc check lib/</code></pre>
+    </section>
+
+    <!-- ============================================================= -->
+    <section>
+      <h2>LSP server (coming soon)</h2>
+      <p>PSC includes a built-in LSP server (<code>psc lsp</code>) that will deliver hover tooltips, inline diagnostics, go-to-definition, and document symbols directly to any LSP-capable editor. When it ships, editor configuration will be a single entry pointing at the <code>psc lsp</code> command — no bridge tools required.</p>
+      <p>In the meantime, the <code>psc check</code> integrations above give you the same diagnostic coverage. The LSP server will add real-time feedback as you type.</p>
+    </section>
+  </main>
+
+  <footer>
+    <p>PVM is licensed under the <a href="https://opensource.org/license/artistic-2-0">Artistic License 2.0</a>. <a href="https://github.com/perigrin/pvm">GitHub</a></p>
+  </footer>
+  <script src="../scripts/copy-code.js"></script>
+  <script src="../scripts/nav.js"></script>
+</body>
+</html>

--- a/guides/type-checking.html
+++ b/guides/type-checking.html
@@ -153,7 +153,7 @@ my $result = MyModule::process($data);  # return type inferred from MyModule</co
         <li><strong>Go-to-definition</strong> — jumps to the declaration of a variable or subroutine</li>
         <li><strong>Document symbols</strong> — lists all symbols defined in the current file</li>
       </ul>
-      <p>Guard suggestions appear as diagnostic hints alongside the inline errors, so you can see them without leaving your editor. See the <a href="../reference/psc.html">psc reference</a> for editor configuration details.</p>
+      <p>Guard suggestions appear as diagnostic hints alongside the inline errors, so you can see them without leaving your editor. See the <a href="editor-setup.html">Editor Setup guide</a> for copy-paste configurations for Vim, Neovim, VS Code, Emacs, Sublime Text, and Helix.</p>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -43,30 +43,8 @@
       <p>Single binary. Pure Go. No dependencies.</p>
 
       <div class="install-block">
-        <div class="platform-tabs" role="tablist" aria-label="Platform">
-          <button role="tab" aria-selected="true" aria-controls="install-linux-amd64" id="tab-linux-amd64">Linux (AMD64)</button>
-          <button role="tab" aria-selected="false" aria-controls="install-linux-arm64" id="tab-linux-arm64">Linux (ARM64)</button>
-          <button role="tab" aria-selected="false" aria-controls="install-darwin-arm64" id="tab-darwin-arm64">macOS (Apple Silicon)</button>
-        </div>
-        <div role="tabpanel" id="install-linux-amd64" aria-labelledby="tab-linux-amd64">
-          <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-linux-amd64.tar.gz
-tar -xzf pvm-linux-amd64.tar.gz
-sudo mv pvm /usr/local/bin/pvm
-eval "$(pvm init)"</code></pre>
-        </div>
-        <div role="tabpanel" id="install-linux-arm64" aria-labelledby="tab-linux-arm64" hidden>
-          <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-linux-arm64.tar.gz
-tar -xzf pvm-linux-arm64.tar.gz
-sudo mv pvm /usr/local/bin/pvm
-eval "$(pvm init)"</code></pre>
-        </div>
-        <div role="tabpanel" id="install-darwin-arm64" aria-labelledby="tab-darwin-arm64" hidden>
-          <pre><code>curl -LO https://github.com/perigrin/pvm/releases/latest/download/pvm-darwin-arm64.tar.gz
-tar -xzf pvm-darwin-arm64.tar.gz
-chmod +x pvm
-sudo mv pvm /usr/local/bin/pvm
-eval "$(pvm init)"</code></pre>
-        </div>
+        <pre><code>curl -fsSL https://pvm.tools/install.sh | sh</code></pre>
+        <p style="margin-top: 0.5em; font-size: 0.9em; opacity: 0.7;">Detects your platform automatically. Installs to <code>~/.local/bin</code>.</p>
       </div>
 
       <div class="cta-group">

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# ABOUTME: PVM installer script — detects platform, downloads latest release, installs binary
+# ABOUTME: Hosted at https://pvm.tools/install.sh for curl-pipe-sh installation
+
+set -eu
+
+REPO="perigrin/pvm"
+INSTALL_DIR="${PVM_INSTALL_DIR:-$HOME/.local/bin}"
+
+main() {
+    detect_platform
+    fetch_latest_release
+    download_and_install
+    print_success
+}
+
+detect_platform() {
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    case "$OS" in
+        linux)  PLATFORM_OS="linux" ;;
+        darwin) PLATFORM_OS="darwin" ;;
+        *)
+            echo "Error: unsupported operating system: $OS" >&2
+            exit 1
+            ;;
+    esac
+
+    case "$ARCH" in
+        x86_64|amd64)  PLATFORM_ARCH="amd64" ;;
+        aarch64|arm64) PLATFORM_ARCH="arm64" ;;
+        *)
+            echo "Error: unsupported architecture: $ARCH" >&2
+            exit 1
+            ;;
+    esac
+
+    PLATFORM="${PLATFORM_OS}-${PLATFORM_ARCH}"
+    echo "Detected platform: $PLATFORM"
+}
+
+fetch_latest_release() {
+    echo "Fetching latest release..."
+    RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases?per_page=1")
+
+    TAG=$(echo "$RELEASE_JSON" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+    VERSION="${TAG#v}"
+
+    if [ -z "$TAG" ]; then
+        echo "Error: could not determine latest release" >&2
+        exit 1
+    fi
+
+    echo "Latest release: $TAG"
+}
+
+download_and_install() {
+    ASSET_NAME="pvm-${VERSION}-${PLATFORM}.tar.gz"
+    DOWNLOAD_URL="https://github.com/${REPO}/releases/download/${TAG}/${ASSET_NAME}"
+
+    TMPDIR=$(mktemp -d)
+    trap 'rm -rf "$TMPDIR"' EXIT
+
+    echo "Downloading $ASSET_NAME..."
+    curl -fsSL -o "${TMPDIR}/${ASSET_NAME}" "$DOWNLOAD_URL"
+
+    echo "Extracting..."
+    tar -xzf "${TMPDIR}/${ASSET_NAME}" -C "$TMPDIR"
+
+    mkdir -p "$INSTALL_DIR"
+    mv "${TMPDIR}/pvm-${PLATFORM}" "${INSTALL_DIR}/pvm"
+    chmod +x "${INSTALL_DIR}/pvm"
+
+    echo "Installed pvm to ${INSTALL_DIR}/pvm"
+}
+
+print_success() {
+    echo ""
+    echo "PVM $VERSION installed successfully."
+    echo ""
+
+    # Check if install dir is in PATH
+    case ":$PATH:" in
+        *":${INSTALL_DIR}:"*) ;;
+        *)
+            echo "Add ${INSTALL_DIR} to your PATH:"
+            echo ""
+            echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+            echo ""
+            ;;
+    esac
+
+    echo "Then add shell integration to your profile:"
+    echo ""
+    echo "  # bash (~/.bashrc) or zsh (~/.zshrc)"
+    echo "  eval \"\$(pvm init)\""
+    echo ""
+    echo "  # fish (~/.config/fish/config.fish)"
+    echo "  pvm init | source"
+    echo ""
+}
+
+main

--- a/reference/psc.html
+++ b/reference/psc.html
@@ -95,6 +95,7 @@ psc check lib/</code></pre>
           <dd>Go-to-definition for symbols with a known declaration site.</dd>
         </dl>
         <pre><code>psc lsp</code></pre>
+        <p>See the <a href="../guides/editor-setup.html">Editor Setup guide</a> for copy-paste configurations for each editor.</p>
       </dd>
     </dl>
   </main>


### PR DESCRIPTION
## Summary

- Add `guides/editor-setup.html` with copy-paste PSC configurations for Vim, Neovim, VS Code, Emacs, Sublime Text, Helix, and CI
- Add `install.sh` for curl-pipe-sh installation that handles pre-releases
- Replace broken `/releases/latest/` URLs across homepage, getting-started, and reference pages
- Add `guides/type-checking-cookbook.html` with practical examples of PSC diagnostics
- Update type-checking guide and PSC reference to link to the editor setup guide

## Files changed
- 6 files changed, 2 new files

## Test plan
- [ ] Verify `curl -fsSL https://pvm.tools/install.sh | sh` works after merge
- [ ] Verify editor-setup.html renders correctly
- [ ] Verify internal links between guides work