### PR TITLE
fix(pvm): document binary-first default, avoid wasted HTTP call

### DIFF
--- a/internal/pvm/command.go
+++ b/internal/pvm/command.go
@@ -134,6 +134,10 @@ func newInstallCommand() *cobra.Command {
 		Short: "Install a Perl version",
 		Long: `Download and install a specific version of Perl.
 
+By default, pvm checks for a pre-compiled binary first and falls back to
+building from source if one is not available. Use --force-source to always
+build from source.
+
 Version can be:
   - Specific version: 5.38.2, 5.40.0
   - Latest stable: latest (installs most recent stable version)
@@ -144,7 +148,8 @@ Examples:
   pvm install 5.38.2        # Install specific version
   pvm install latest        # Install latest stable version
   pvm install latest-dev    # Install latest development version
-  pvm install latest --include-dev  # Install absolute latest (including dev)`,
+  pvm install latest --include-dev   # Install absolute latest (including dev)
+  pvm install 5.40.0 --force-source  # Force source compilation`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			version := args[0]
@@ -175,20 +180,23 @@ Examples:
 			}
 
 			// Resolve version aliases (latest, latest-dev, etc.)
-			versionAliases := map[string]string{}
-			if cfg.PVM != nil && cfg.PVM.VersionAliases != nil {
-				versionAliases = cfg.PVM.VersionAliases
-			}
-			resolvedVersion, err := perl.ResolveVersionAlias(version, versionAliases)
-			if err != nil {
-				return fmt.Errorf("failed to resolve version alias: %w", err)
-			}
-
-			// If using --include-dev with "latest", resolve to latest dev version
+			// When --include-dev is set with "latest", resolve to the absolute
+			// latest version (including dev candidates) to avoid a wasted HTTP
+			// call that would only fetch stable versions.
+			var resolvedVersion string
 			if includeDev && (version == "latest" || version == "@latest") {
 				resolvedVersion, err = perl.ResolveLatestDevVersion()
 				if err != nil {
 					return fmt.Errorf("failed to resolve latest dev version: %w", err)
+				}
+			} else {
+				versionAliases := map[string]string{}
+				if cfg.PVM != nil && cfg.PVM.VersionAliases != nil {
+					versionAliases = cfg.PVM.VersionAliases
+				}
+				resolvedVersion, err = perl.ResolveVersionAlias(version, versionAliases)
+				if err != nil {
+					return fmt.Errorf("failed to resolve version alias: %w", err)
 				}
 			}
 

--- a/internal/pvm/command_latest_test.go
+++ b/internal/pvm/command_latest_test.go
@@ -364,6 +364,8 @@ func TestInstallCommand_HelpText(t *testing.T) {
 	assert.Contains(t, helpText, "latest-dev")
 	assert.Contains(t, helpText, "--include-dev")
 	assert.Contains(t, helpText, "Examples:")
+	assert.Contains(t, helpText, "pre-compiled binary first")
+	assert.Contains(t, helpText, "--force-source")
 }
 
 func TestAvailableCommand_HelpText_WithDev(t *testing.T) {


### PR DESCRIPTION
## Summary

Address review suggestions from the agentic code review on PR #425:

- **S2**: Help text now documents that pvm checks for pre-compiled binaries first by default, and shows `--force-source` in the examples
- **S3**: When `--include-dev` is used with `latest`, resolve directly to the dev version instead of resolving stable first (wasted HTTP round-trip to MetaCPAN) and then immediately overriding with the dev resolution
- **S6**: Tracked as #426 (project-level config trust boundary)
- **S5**: Will be addressed in the upcoming light mode work

## Changes

- 2 files changed, 20 insertions, 11 deletions
- `internal/pvm/command.go` — updated help text, restructured version resolution to avoid redundant HTTP call
- `internal/pvm/command_latest_test.go` — added assertions for new help text content

## Test plan

- [x] `make test` — all packages pass
- [x] Help text tests verify new content (`pre-compiled binary first`, `--force-source`)