### PR TITLE
fix(updater): self-update archive extraction and token warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,17 +112,21 @@ jobs:
       if: matrix.goos != 'windows'
       env:
         VERSION: ${{ steps.version.outputs.version }}
+        PLATFORM: ${{ matrix.platform }}
       run: |
         cd build/release
-        tar -czf "pvm-${VERSION}-${{ matrix.platform }}.tar.gz" "pvm-${{ matrix.platform }}"
+        mv "pvm-${PLATFORM}" pvm
+        tar -czf "pvm-${VERSION}-${PLATFORM}.tar.gz" pvm
 
     - name: Create archive (Windows)
       if: matrix.goos == 'windows'
       env:
         VERSION: ${{ steps.version.outputs.version }}
+        PLATFORM: ${{ matrix.platform }}
       run: |
         cd build/release
-        zip "pvm-${VERSION}-${{ matrix.platform }}.zip" "pvm-${{ matrix.platform }}.exe"
+        mv "pvm-${PLATFORM}.exe" pvm.exe
+        zip "pvm-${VERSION}-${PLATFORM}.zip" pvm.exe
 
     - name: Upload artifact (Unix)
       if: matrix.goos != 'windows'
@@ -185,7 +189,7 @@ jobs:
     - name: Organize release files
       run: |
         mkdir -p release-files
-        find artifacts -name "*.tar.gz" -exec cp {} release-files/ \;
+        find artifacts \( -name "*.tar.gz" -o -name "*.zip" \) -exec cp {} release-files/ \;
         ls -la release-files/
 
     - name: Generate release notes
@@ -218,8 +222,8 @@ jobs:
           echo ""
           echo '```bash'
           echo "tar -xzf pvm-${VERSION}-<platform>.tar.gz"
-          echo "chmod +x pvm-*"
-          echo "sudo mv pvm-* /usr/local/bin/pvm"
+          echo "chmod +x pvm"
+          echo "sudo mv pvm /usr/local/bin/pvm"
           echo "pvm version"
           echo '```'
         } > release_notes.md

--- a/internal/archive/extractor.go
+++ b/internal/archive/extractor.go
@@ -236,12 +236,15 @@ func (e *BinaryExtractor) validatePath(path string) error {
 
 // findMainExecutable finds the main executable from extracted files
 func (e *BinaryExtractor) findMainExecutable(extractedFiles []string, platform string) (string, error) {
-	// Define expected executable names by platform
+	// Define expected executable names by platform.
+	// Prefer the canonical name (pvm / pvm.exe) but also accept
+	// platform-suffixed names (pvm-linux-amd64, pvm-darwin-arm64)
+	// for backwards compatibility with older release archives.
 	var expectedNames []string
 	if strings.HasPrefix(platform, "windows") {
-		expectedNames = []string{"pvm.exe"}
+		expectedNames = []string{"pvm.exe", "pvm-" + platform + ".exe"}
 	} else {
-		expectedNames = []string{"pvm"}
+		expectedNames = []string{"pvm", "pvm-" + platform}
 	}
 
 	// Look for executable in common locations
@@ -277,6 +280,19 @@ func (e *BinaryExtractor) findMainExecutable(extractedFiles []string, platform s
 	}
 
 	if len(candidates) > 1 {
+		// If candidates have different base names (e.g. "pvm" and "pvm-linux-amd64"),
+		// prefer the canonical name (first in expectedNames). If they have the same
+		// base name in different directories, that is genuinely ambiguous.
+		canonicalName := expectedNames[0]
+		var canonicalCandidates []string
+		for _, c := range candidates {
+			if filepath.Base(c) == canonicalName {
+				canonicalCandidates = append(canonicalCandidates, c)
+			}
+		}
+		if len(canonicalCandidates) == 1 {
+			return canonicalCandidates[0], nil
+		}
 		return "", fmt.Errorf("multiple executables found: %v", candidates)
 	}
 

--- a/internal/archive/extractor_test.go
+++ b/internal/archive/extractor_test.go
@@ -42,6 +42,14 @@ func TestBinaryExtractor_ExtractExecutable(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "tar.gz with platform-named binary (fallback)",
+			createArchive: func(t *testing.T) string {
+				return createTestTarGz(t, "pvm-darwin-arm64", createMockBinary())
+			},
+			platform:    "darwin-arm64",
+			expectError: false,
+		},
+		{
 			name: "archive without executable",
 			createArchive: func(t *testing.T) string {
 				return createTestTarGz(t, "README.txt", []byte("documentation"))
@@ -85,12 +93,14 @@ func TestBinaryExtractor_ExtractExecutable(t *testing.T) {
 				_, err := os.Stat(extractedPath)
 				assert.NoError(t, err)
 
-				// Verify it has correct name
+				// Verify the extracted file has a recognized name
 				filename := filepath.Base(extractedPath)
 				if strings.HasPrefix(tt.platform, "windows") {
-					assert.Equal(t, "pvm.exe", filename)
+					assert.True(t, filename == "pvm.exe" || filename == "pvm-"+tt.platform+".exe",
+						"expected pvm.exe or pvm-%s.exe, got %s", tt.platform, filename)
 				} else {
-					assert.Equal(t, "pvm", filename)
+					assert.True(t, filename == "pvm" || filename == "pvm-"+tt.platform,
+						"expected pvm or pvm-%s, got %s", tt.platform, filename)
 				}
 
 				// Cleanup
@@ -181,6 +191,25 @@ func TestBinaryExtractor_FindMainExecutable(t *testing.T) {
 			platform:     "windows-amd64",
 			expectError:  false,
 			expectedFile: "pvm.exe",
+		},
+		{
+			name: "platform-named binary (pvm-darwin-arm64)",
+			files: map[string][]byte{
+				"pvm-darwin-arm64": createMockBinary(),
+				"README.txt":       []byte("documentation"),
+			},
+			platform:     "darwin-arm64",
+			expectError:  false,
+			expectedFile: "pvm-darwin-arm64",
+		},
+		{
+			name: "platform-named binary (pvm-linux-amd64)",
+			files: map[string][]byte{
+				"pvm-linux-amd64": createMockBinary(),
+			},
+			platform:     "linux-amd64",
+			expectError:  false,
+			expectedFile: "pvm-linux-amd64",
 		},
 		{
 			name: "no executable found",

--- a/internal/pvm/update.go
+++ b/internal/pvm/update.go
@@ -5,6 +5,7 @@ package pvm
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -54,15 +55,6 @@ func executeUpdateCommand(cmd *cobra.Command, args []string) error {
 		updaterInstance = updater.NewUpdaterWithToken(effectiveToken)
 	} else {
 		updaterInstance = updater.NewUpdater()
-		// Warn about GitHub token requirement for private repositories
-		cmd.Printf("Warning: No GitHub token configured.\n")
-		cmd.Printf("A GitHub token is required to access releases from private repositories.\n")
-		cmd.Printf("To configure authentication:\n")
-		cmd.Printf("  1. Use --token flag: pvm update --token YOUR_TOKEN\n")
-		cmd.Printf("  2. Set environment variable: export GITHUB_TOKEN=YOUR_TOKEN\n")
-		cmd.Printf("  3. Configure permanently in ~/.config/pvm/config.toml:\n")
-		cmd.Printf("     [pvm.update]\n")
-		cmd.Printf("     github_token = \"${GITHUB_TOKEN}\"\n\n")
 	}
 
 	// Determine effective prerelease setting (flag overrides config)
@@ -126,6 +118,13 @@ func executeUpdateCommand(cmd *cobra.Command, args []string) error {
 	cmd.Println("Checking for updates...")
 	updateInfo, err := updaterInstance.CheckForUpdates(opts)
 	if err != nil {
+		// Provide a helpful hint if the error looks like an auth or rate limit problem
+		errMsg := err.Error()
+		if strings.Contains(errMsg, "returned 401") || strings.Contains(errMsg, "returned 403") || strings.Contains(errMsg, "rate limit") {
+			cmd.Println("Hint: A GitHub token may be required. Configure one with:")
+			cmd.Println("  pvm update --token YOUR_TOKEN")
+			cmd.Println("  export GITHUB_TOKEN=YOUR_TOKEN")
+		}
 		return fmt.Errorf("failed to check for updates: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Fixes `pvm self update` failing with "no executable found in archive (expected: [pvm])" reported by CromeDome. Three issues:

- **Archive naming**: Release workflow archived binaries with platform-specific names (`pvm-darwin-arm64`) but the extractor only looked for `pvm`. Now renames to `pvm` before archiving.
- **Extractor resilience**: Also accepts `pvm-{platform}` names as fallback, so existing archives (rc66 and earlier) still work with the updated extractor.
- **Token warning spam**: The "No GitHub token configured" warning appeared unconditionally on every update, even for the public repo. Removed the pre-emptive warning; auth hints now only appear when the API returns 401/403.

## Changes

- 4 files changed, 54 insertions, 19 deletions
- `.github/workflows/release.yml` — rename binary before archiving, fix install instructions
- `internal/archive/extractor.go` — accept platform-suffixed binary names
- `internal/archive/extractor_test.go` — tests for platform-named binaries
- `internal/pvm/update.go` — remove pre-emptive token warning, add contextual auth hint

## Test plan

- [x] `make test` — all packages pass
- [x] Extractor finds `pvm-darwin-arm64` in archive (new test)
- [x] Extractor finds `pvm-linux-amd64` in archive (new test)
- [x] Existing tests for `pvm` and `pvm.exe` still pass
- [ ] Release workflow change needs manual verification on next tag push