### PR TITLE
fix(updater): pass extracted binary to ReplaceBinary, not archive path

### DIFF
--- a/internal/download/validation.go
+++ b/internal/download/validation.go
@@ -286,69 +286,74 @@ func (v *BinaryValidator) validateFileFormat(header []byte, filePath string) err
 	return fmt.Errorf("unrecognized file format (not a valid executable)")
 }
 
-// ValidateDownloadedBinary performs comprehensive validation of a downloaded binary or archive
-func ValidateDownloadedBinary(filePath, expectedChecksum string) error {
+// ValidateDownloadedBinary performs comprehensive validation of a downloaded binary or archive.
+// Returns the path to the usable binary (which may be an extracted file from an archive).
+// The caller is responsible for cleaning up any extracted temporary files.
+func ValidateDownloadedBinary(filePath, expectedChecksum string) (string, error) {
 	return ValidateDownloadedBinaryWithVersion(filePath, expectedChecksum, "")
 }
 
-// ValidateDownloadedBinaryWithVersion performs comprehensive validation including version verification
-func ValidateDownloadedBinaryWithVersion(filePath, expectedChecksum, expectedVersion string) error {
+// ValidateDownloadedBinaryWithVersion performs comprehensive validation including version verification.
+// Returns the path to the validated binary. For archives, this is the path to the extracted
+// binary in a temporary directory — the caller must clean up this path when done.
+func ValidateDownloadedBinaryWithVersion(filePath, expectedChecksum, expectedVersion string) (string, error) {
 	// First validate checksum if provided
 	if expectedChecksum != "" {
 		validator := NewChecksumValidator()
 		if err := validator.ValidateFile(filePath, expectedChecksum); err != nil {
-			return fmt.Errorf("checksum validation failed: %w", err)
+			return "", fmt.Errorf("checksum validation failed: %w", err)
 		}
 	}
 
 	// Check if this is an archive that needs extraction
 	var binaryPath string
-	var cleanup func() error
+	var extractor *archive.BinaryExtractor
 
 	if isArchive(filePath) {
 		// Extract binary from archive
-		extractor := archive.NewBinaryExtractor()
+		extractor = archive.NewBinaryExtractor()
 		platform := detectPlatform()
 
 		extractedPath, err := extractor.ExtractExecutable(filePath, platform)
 		if err != nil {
-			return fmt.Errorf("archive extraction failed: %w", err)
+			return "", fmt.Errorf("archive extraction failed: %w", err)
 		}
 
 		binaryPath = extractedPath
-		cleanup = func() error { return extractor.Cleanup(extractedPath) }
 	} else {
 		binaryPath = filePath
-		cleanup = func() error { return nil }
 	}
-
-	// Ensure cleanup happens
-	defer func() {
-		if err := cleanup(); err != nil {
-			// Log cleanup error but don't fail validation
-			fmt.Fprintf(os.Stderr, "Warning: cleanup failed: %v\n", err)
-		}
-	}()
 
 	// Validate binary format
 	binaryValidator := NewBinaryValidator()
 	if err := binaryValidator.ValidateExecutable(binaryPath); err != nil {
-		return fmt.Errorf("binary validation failed: %w", err)
+		cleanupExtracted(extractor, binaryPath)
+		return "", fmt.Errorf("binary validation failed: %w", err)
 	}
 
 	// Validate version if provided
 	if expectedVersion != "" {
 		if err := validateExecutableVersion(binaryPath, expectedVersion); err != nil {
-			return fmt.Errorf("version validation failed: %w", err)
+			cleanupExtracted(extractor, binaryPath)
+			return "", fmt.Errorf("version validation failed: %w", err)
 		}
 	}
 
 	// Perform execution test
 	if err := validateExecutableCanRun(binaryPath); err != nil {
-		return fmt.Errorf("execution validation failed: %w", err)
+		cleanupExtracted(extractor, binaryPath)
+		return "", fmt.Errorf("execution validation failed: %w", err)
 	}
 
-	return nil
+	return binaryPath, nil
+}
+
+// cleanupExtracted removes the extracted temp directory on validation failure.
+// Safe to call with nil extractor (no-op for non-archive paths).
+func cleanupExtracted(extractor *archive.BinaryExtractor, extractedPath string) {
+	if extractor != nil {
+		extractor.Cleanup(extractedPath)
+	}
 }
 
 // isArchive checks if the file is an archive format

--- a/internal/download/validation_test.go
+++ b/internal/download/validation_test.go
@@ -158,8 +158,13 @@ func TestValidateDownloadedBinary_Archive(t *testing.T) {
 		archivePath := createTestTarGz(t, tarFilename, binaryContent)
 		defer os.Remove(archivePath)
 
-		err := ValidateDownloadedBinary(archivePath, "")
+		binaryPath, err := ValidateDownloadedBinary(archivePath, "")
 		assert.NoError(t, err)
+		if err == nil {
+			assert.NotEqual(t, archivePath, binaryPath, "should return extracted binary path, not archive path")
+			_, statErr := os.Stat(binaryPath)
+			assert.NoError(t, statErr, "extracted binary should exist")
+		}
 	})
 
 	// Test zip archive
@@ -173,8 +178,11 @@ func TestValidateDownloadedBinary_Archive(t *testing.T) {
 		archivePath := createTestZip(t, filename, binaryContent)
 		defer os.Remove(archivePath)
 
-		err := ValidateDownloadedBinary(archivePath, "")
+		binaryPath, err := ValidateDownloadedBinary(archivePath, "")
 		assert.NoError(t, err)
+		if err == nil {
+			assert.NotEqual(t, archivePath, binaryPath, "should return extracted binary path, not archive path")
+		}
 	})
 }
 
@@ -194,8 +202,9 @@ func TestValidateDownloadedBinary_Direct(t *testing.T) {
 	err = os.Chmod(tempFile.Name(), 0755)
 	require.NoError(t, err)
 
-	err = ValidateDownloadedBinary(tempFile.Name(), "")
+	binaryPath, err := ValidateDownloadedBinary(tempFile.Name(), "")
 	assert.NoError(t, err)
+	assert.Equal(t, tempFile.Name(), binaryPath, "for direct binaries, should return the same path")
 }
 
 func TestIsArchive(t *testing.T) {

--- a/internal/updater/recovery.go
+++ b/internal/updater/recovery.go
@@ -395,16 +395,22 @@ func (rm *RecoveryManager) downloadCompatibleVersion(ctx *RecoveryContext) error
 	}
 
 	// Validate the downloaded binary
-	if err := download.ValidateDownloadedBinary(result.Path, ""); err != nil {
+	validatedPath, err := download.ValidateDownloadedBinary(result.Path, "")
+	if err != nil {
 		// Clean up failed download
 		os.Remove(result.Path)
 		return fmt.Errorf("downloaded binary validation failed: %w", err)
 	}
 
-	// Atomically replace the target binary
-	if err := os.Rename(result.Path, ctx.TargetPath); err != nil {
+	// Clean up extraction temp directory when done (no-op for direct binaries)
+	if validatedPath != result.Path {
+		defer os.RemoveAll(filepath.Dir(validatedPath))
+	}
+
+	// Atomically replace the target binary using the validated binary path
+	if err := os.Rename(validatedPath, ctx.TargetPath); err != nil {
 		// Clean up on failure
-		os.Remove(result.Path)
+		os.Remove(validatedPath)
 		return fmt.Errorf("failed to install compatible version: %w", err)
 	}
 

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -289,11 +289,18 @@ func (u *Updater) PerformUpdate(opts *UpdateOptions) (*UpdateResult, error) {
 		return result, err
 	}
 
-	// Validate downloaded binary with version verification
+	// Validate downloaded binary with version verification.
+	// For archives, this extracts the binary and returns the extracted path.
 	reportProgress(StageValidating, "Validating download", 0.6)
-	if err := download.ValidateDownloadedBinaryWithVersion(downloadResult.Path, "", result.NewVersion); err != nil {
+	validatedBinaryPath, err := download.ValidateDownloadedBinaryWithVersion(downloadResult.Path, "", result.NewVersion)
+	if err != nil {
 		result.Message = fmt.Sprintf("Downloaded binary validation failed: %v", err)
 		return result, err
+	}
+
+	// Clean up the extraction temp directory when done (no-op for direct binaries)
+	if validatedBinaryPath != downloadResult.Path {
+		defer os.RemoveAll(filepath.Dir(validatedBinaryPath))
 	}
 
 	// Perform replacement (or simulate if dry run)
@@ -323,7 +330,7 @@ func (u *Updater) PerformUpdate(opts *UpdateOptions) (*UpdateResult, error) {
 	reportProgress(StageReplacing, "Installing update", 0.8)
 	replaceOpts := &ReplacementOptions{
 		CurrentPath:    currentPath,
-		NewPath:        downloadResult.Path,
+		NewPath:        validatedBinaryPath,
 		BackupEnabled:  false, // We already created backup above
 		ValidateBinary: true,
 		DryRun:         false,

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -495,11 +495,13 @@ func TestUpdateWithArchiveExtraction_Integration(t *testing.T) {
 		defer os.Remove(archivePath)
 
 		// Test that ValidateDownloadedBinary works with archives
-		err := download.ValidateDownloadedBinary(archivePath, "")
+		binaryPath, err := download.ValidateDownloadedBinary(archivePath, "")
 		if err != nil {
 			t.Logf("Archive validation failed (expected in test environment): %v", err)
 			// This may fail in test environment due to execution validation,
 			// but we want to test that archive extraction works
+		} else if binaryPath == archivePath {
+			t.Error("ValidateDownloadedBinary should return extracted binary path, not archive path")
 		}
 	})
 
@@ -542,7 +544,7 @@ func TestUpdateValidationFailure_Integration(t *testing.T) {
 		defer os.Remove(invalidArchive)
 
 		// Test that validation properly fails
-		err := download.ValidateDownloadedBinary(invalidArchive, "")
+		_, err := download.ValidateDownloadedBinary(invalidArchive, "")
 		if err == nil {
 			t.Error("Expected validation to fail for invalid archive")
 		}
@@ -553,7 +555,7 @@ func TestUpdateValidationFailure_Integration(t *testing.T) {
 		archivePath := createArchiveWithoutExecutable(t)
 		defer os.Remove(archivePath)
 
-		err := download.ValidateDownloadedBinary(archivePath, "")
+		_, err := download.ValidateDownloadedBinary(archivePath, "")
 		if err == nil {
 			t.Error("Expected validation to fail for archive without executable")
 		}


### PR DESCRIPTION
## Summary

Fixes #429. The self-update downloaded an archive, validated the extracted binary, then passed the **archive path** to `ReplaceBinary` instead of the extracted binary path. This caused the update to fail with "no executable found in archive" or could corrupt installations.

- `ValidateDownloadedBinaryWithVersion` now returns `(string, error)` — the string is the path to the usable binary (extracted from archive, or the original file for direct binaries)
- `PerformUpdate` in `updater.go` uses the returned binary path for `ReplaceBinary`
- `recovery.go` fixed the same bug: `os.Rename` now uses the validated binary path

## Changes

- 5 files changed, 41 insertions, 34 deletions
- `internal/download/validation.go` — changed return type to `(string, error)`
- `internal/updater/updater.go` — use validated binary path for replacement
- `internal/updater/recovery.go` — use validated binary path for rename
- `internal/download/validation_test.go` — verify returned path differs from archive path
- `internal/updater/updater_test.go` — updated for new return type

## Test plan

- [x] `make test` — all packages pass
- [x] Archive validation returns extracted path, not archive path (new assertion)
- [x] Direct binary validation returns original path (new assertion)
- [x] Invalid archive and missing executable tests still pass