### PR TITLE
feat(cli): auto-detect terminal background for light/dark help colors

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/fang"
+	"github.com/charmbracelet/lipgloss/v2"
 	"github.com/spf13/cobra"
 	"tamarou.com/pvm/internal/cli/ui"
 	"tamarou.com/pvm/internal/current"
@@ -281,8 +282,14 @@ func FangExecuteWithPager(ctx context.Context, rootCmd *cobra.Command) error {
 	ui := GetUI(rootCmd)
 	styles := ui.Styles()
 
-	// Create Fang color scheme from UI styles
-	colorScheme := styles.FangColorScheme()
+	// Detect terminal background and create adapted Fang color scheme.
+	// Only query the terminal when attached to a tty to avoid a 2-second
+	// timeout in non-responsive environments (screen, some containers).
+	isDark := true
+	if isTerminal(os.Stdin) || isTerminal(os.Stdout) {
+		isDark = lipgloss.HasDarkBackground(os.Stdin, os.Stdout)
+	}
+	colorScheme := styles.FangColorScheme(isDark)
 
 	// Check if we're showing basic help (no arguments) and use our hybrid help system instead of Fang's
 	args := os.Args[1:]

--- a/internal/cli/ui/styles.go
+++ b/internal/cli/ui/styles.go
@@ -158,34 +158,37 @@ func NewStyles(theme Theme) Styles {
 	}
 }
 
-// FangColorScheme creates Fang-compatible color scheme from PVM theme.
+// FangColorScheme creates a Fang-compatible color scheme adapted for the
+// terminal's background brightness. Pass isDark=true for dark terminals,
+// isDark=false for light terminals.
 //
 // Fang uses Codeblock as a BACKGROUND color for code example blocks, so it
-// must be a dark, muted shade — not a bright foreground color. All foreground
-// colors rendered inside the codeblock (Program, Command, Flag, Argument,
-// DimmedArgument, Comment, QuotedString) must contrast against it.
+// must contrast with the terminal background. All foreground colors rendered
+// inside the codeblock must contrast against the codeblock background.
 //
 // Colors are chosen to be distinguishable under common forms of color
 // blindness (protanopia, deuteranopia): we avoid pairing red and green,
 // and rely on blue/purple/amber hue differences instead.
-func (s Styles) FangColorScheme() fang.ColorScheme {
+func (s Styles) FangColorScheme(isDark bool) fang.ColorScheme {
+	c := lipgloss.LightDark(isDark)
+
 	return fang.ColorScheme{
-		Base:           lipgloss.Color("#DFDBDD"),                                            // Light gray body text — readable on dark and light terminals
-		Title:          s.Header.GetForeground(),                                             // Purple (#7C3AED) — section headers
-		Description:    lipgloss.Color("#BFBCC8"),                                            // Muted lavender-gray — flag/command descriptions
-		Codeblock:      lipgloss.Color("#2D2B36"),                                            // Dark gray BG for code blocks — high contrast with all FG colors
-		Program:        lipgloss.Color("#9B8AFF"),                                            // Soft purple — program name, distinct from command
-		DimmedArgument: s.Muted.GetForeground(),                                              // Medium gray (#9CA3AF) — optional args
-		Comment:        lipgloss.Color("#9896A6"),                                            // Gray — code comments
-		Flag:           lipgloss.Color("#F5C542"),                                            // Warm gold — flags, distinct from all other hues under CVD
-		FlagDefault:    s.Muted.GetForeground(),                                              // Medium gray (#9CA3AF) — default values
-		Command:        lipgloss.Color("#5EB5FF"),                                            // Sky blue — subcommands, easily separated from purple and gold
-		QuotedString:   lipgloss.Color("#DFDBDD"),                                            // Light gray — quoted strings, neutral
-		Argument:       lipgloss.Color("#DFDBDD"),                                            // Light gray — argument values
-		Help:           lipgloss.Color("#DFDBDD"),                                            // Light gray — help text
-		Dash:           s.Muted.GetForeground(),                                              // Medium gray (#9CA3AF) — flag dashes
-		ErrorHeader:    [2]color.Color{lipgloss.Color("#FFFAF1"), lipgloss.Color("#C43A5A")}, // Cream on deep rose — error badge
-		ErrorDetails:   lipgloss.Color("#F08090"),                                            // Soft rose — error text, not pure red
+		Base:           c(lipgloss.Color("#3A3943"), lipgloss.Color("#DFDBDD")),                                                                          // Body text
+		Title:          s.Header.GetForeground(),                                                                                                         // Purple — section headers
+		Description:    c(lipgloss.Color("#605F6B"), lipgloss.Color("#BFBCC8")),                                                                          // Flag/command descriptions
+		Codeblock:      c(lipgloss.Color("#F0EDE8"), lipgloss.Color("#2D2B36")),                                                                          // Code block background
+		Program:        c(lipgloss.Color("#4A30D9"), lipgloss.Color("#9B8AFF")),                                                                          // Purple — program name
+		DimmedArgument: c(lipgloss.Color("#6B6A78"), s.Muted.GetForeground()),                                                                            // Gray — optional args
+		Comment:        c(lipgloss.Color("#6B6A78"), lipgloss.Color("#9896A6")),                                                                          // Gray — code comments
+		Flag:           c(lipgloss.Color("#785A0F"), lipgloss.Color("#F5C542")),                                                                          // Amber — flags
+		FlagDefault:    c(lipgloss.Color("#6B6A78"), s.Muted.GetForeground()),                                                                            // Gray — default values
+		Command:        c(lipgloss.Color("#1A5276"), lipgloss.Color("#5EB5FF")),                                                                          // Blue — subcommands
+		QuotedString:   c(lipgloss.Color("#3A3943"), lipgloss.Color("#DFDBDD")),                                                                          // Neutral — quoted strings
+		Argument:       c(lipgloss.Color("#3A3943"), lipgloss.Color("#DFDBDD")),                                                                          // Neutral — argument values
+		Help:           c(lipgloss.Color("#3A3943"), lipgloss.Color("#DFDBDD")),                                                                          // Neutral — help text
+		Dash:           c(lipgloss.Color("#6B6A78"), s.Muted.GetForeground()),                                                                            // Gray — flag dashes
+		ErrorHeader:    [2]color.Color{c(lipgloss.Color("#FFFAF1"), lipgloss.Color("#FFFAF1")), c(lipgloss.Color("#B0304A"), lipgloss.Color("#C43A5A"))}, // Error badge
+		ErrorDetails:   c(lipgloss.Color("#B0304A"), lipgloss.Color("#F08090")),                                                                          // Error text
 	}
 }
 

--- a/internal/cli/ui/styles_test.go
+++ b/internal/cli/ui/styles_test.go
@@ -86,7 +86,7 @@ func TestStylesCreation(t *testing.T) {
 
 func TestFangColorSchemeCreation(t *testing.T) {
 	styles := GetDefaultStyles()
-	colorScheme := styles.FangColorScheme()
+	colorScheme := styles.FangColorScheme(true)
 
 	// Test that ColorScheme is created properly
 	if colorScheme.Base == nil {
@@ -232,29 +232,78 @@ func TestStylesConsistency(t *testing.T) {
 
 func TestFangColorSchemeMapping(t *testing.T) {
 	styles := GetDefaultStyles()
-	colorScheme := styles.FangColorScheme()
 
-	// Test that color scheme has all required colors
-	if colorScheme.Base == nil {
-		t.Error("ColorScheme Base should not be nil")
-	}
-	if colorScheme.Title == nil {
-		t.Error("ColorScheme Title should not be nil")
-	}
-	if colorScheme.Command == nil {
-		t.Error("ColorScheme Command should not be nil")
-	}
-	if colorScheme.ErrorDetails == nil {
-		t.Error("ColorScheme ErrorDetails should not be nil")
-	}
+	t.Run("dark mode", func(t *testing.T) {
+		colorScheme := styles.FangColorScheme(true)
 
-	// Test that Title still maps to the Header foreground
-	if colorScheme.Title != styles.Header.GetForeground() {
-		t.Error("ColorScheme Title should match Header foreground")
-	}
+		if colorScheme.Base == nil {
+			t.Error("ColorScheme Base should not be nil")
+		}
+		if colorScheme.Title == nil {
+			t.Error("ColorScheme Title should not be nil")
+		}
+		if colorScheme.Command == nil {
+			t.Error("ColorScheme Command should not be nil")
+		}
+		if colorScheme.ErrorDetails == nil {
+			t.Error("ColorScheme ErrorDetails should not be nil")
+		}
+		if colorScheme.Title != styles.Header.GetForeground() {
+			t.Error("ColorScheme Title should match Header foreground")
+		}
+		if colorScheme.Codeblock == styles.Code.GetForeground() {
+			t.Error("ColorScheme Codeblock must not use Code foreground as background")
+		}
+	})
 
-	// Codeblock is used as a BACKGROUND, so it must not be a bright foreground color
-	if colorScheme.Codeblock == styles.Code.GetForeground() {
-		t.Error("ColorScheme Codeblock must not use Code foreground as background — it needs a dark, muted color")
-	}
+	t.Run("light mode", func(t *testing.T) {
+		colorScheme := styles.FangColorScheme(false)
+
+		if colorScheme.Base == nil {
+			t.Error("ColorScheme Base should not be nil")
+		}
+		if colorScheme.Title == nil {
+			t.Error("ColorScheme Title should not be nil")
+		}
+		if colorScheme.Command == nil {
+			t.Error("ColorScheme Command should not be nil")
+		}
+		if colorScheme.ErrorDetails == nil {
+			t.Error("ColorScheme ErrorDetails should not be nil")
+		}
+	})
+
+	t.Run("light mode Title matches Header foreground", func(t *testing.T) {
+		colorScheme := styles.FangColorScheme(false)
+		if colorScheme.Title != styles.Header.GetForeground() {
+			t.Error("Light mode Title should match Header foreground")
+		}
+	})
+
+	t.Run("dark and light produce different colors", func(t *testing.T) {
+		dark := styles.FangColorScheme(true)
+		light := styles.FangColorScheme(false)
+
+		if dark.Codeblock == light.Codeblock {
+			t.Error("Dark and light codeblock backgrounds should differ")
+		}
+		if dark.Base == light.Base {
+			t.Error("Dark and light base text colors should differ")
+		}
+		if dark.Program == light.Program {
+			t.Error("Dark and light program colors should differ")
+		}
+		if dark.Command == light.Command {
+			t.Error("Dark and light command colors should differ")
+		}
+		if dark.Flag == light.Flag {
+			t.Error("Dark and light flag colors should differ")
+		}
+		if dark.Description == light.Description {
+			t.Error("Dark and light description colors should differ")
+		}
+		if dark.ErrorDetails == light.ErrorDetails {
+			t.Error("Dark and light error details colors should differ")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Adds light mode support to the Fang color scheme. PVM now auto-detects
whether the terminal has a dark or light background using
`lipgloss.HasDarkBackground` and adapts help output colors accordingly.

### Light mode palette
- Codeblock BG: warm light gray (#F0EDE8) — subtle contrast against white terminals
- Program: deep purple (#4A30D9) — 6.62:1 contrast on codeblock BG
- Command: deep blue (#1A5276) — 7.16:1 contrast
- Flag: dark amber (#785A0F) — 5.50:1 contrast
- Body text: near-black (#3A3943) — 9.74:1 contrast
- All pairs WCAG AA compliant (4.5:1+)
- Same CVD-safe hue selection as dark mode (blue/purple/amber, no red-green pairing)

### Dark mode
Unchanged from the prior WCAG-validated scheme.

### Detection
Falls back to dark mode if detection fails (same as lipgloss default).

## Changes

- 3 files changed, 78 insertions, 46 deletions
- `internal/cli/ui/styles.go` — `FangColorScheme(isDark bool)` with light/dark palettes via `lipgloss.LightDark`
- `internal/cli/ui/styles_test.go` — tests for both modes, verifies different colors
- `internal/cli/root.go` — detect background with `lipgloss.HasDarkBackground`

## Test plan

- [x] `make test` — all packages pass
- [x] Dark mode produces same colors as before
- [x] Light mode produces different codeblock/base colors
- [x] All light mode FG/BG pairs verified >= 4.5:1 WCAG AA contrast