### PR TITLE
docs: cover pvm use system semantics and version@library syntax

### DIFF
--- a/guides/isolation.html
+++ b/guides/isolation.html
@@ -77,6 +77,16 @@ pvm env remove myproject   # Delete environment</code></pre>
 
     <p>Activating an environment in your current shell sets <code>PERL5LIB</code> so that interactive use and editor tooling pick up the same modules your scripts see.</p>
 
+    <h3>Pairing a Perl version with a library</h3>
+    <p>Named environments are normally scoped to the currently-active Perl version. If you want to switch Perl version and library in one step, <code>pvm use</code> accepts a <code>version@library</code> syntax:</p>
+
+    <pre><code>pvm use 5.42.0@myproject      # use Perl 5.42.0 with the 'myproject' library
+pvm use system@tools          # use system Perl with the 'tools' library</code></pre>
+
+    <p>This activates both the Perl version and the named environment in the current shell: <code>PATH</code> gets the version's <code>bin</code>, and <code>PERL5LIB</code> gets the environment's module tree. Drop the <code>@library</code> part to activate just the Perl version; run <code>pvm use &lt;version&gt;</code> again to clear a previously-active library.</p>
+
+    <p>The library environment must already exist — create one with <code>pvx --name</code> before passing it to <code>pvm use</code>. Use <code>pvm env list</code> to see available environments.</p>
+
     <h2>Environment Variable Control</h2>
     <p>Isolation controls which modules are visible. Environment variable control is a separate concern: which variables from your current shell are passed into the script.</p>
 

--- a/guides/version-resolution.html
+++ b/guides/version-resolution.html
@@ -76,6 +76,13 @@ pvm global system       # Fall back to system Perl</code></pre>
       <dd>Removes the PVM global version setting, letting the system Perl serve as the default.</dd>
     </dl>
 
+    <h3>Passing <code>system</code> to <code>pvm use</code></h3>
+    <p><code>pvm use system</code> clears <code>PVM_PERL_VERSION</code> in the current shell. That removes the env-var override at the top of the resolution chain — but the chain still applies. In a directory with a <code>.perl-version</code> file (or a parent that has one), PVM will resolve to <em>that</em> version, not the OS Perl.</p>
+    <p>To actually activate the OS Perl when inside a project directory, either <code>cd</code> somewhere outside the project tree before running <code>pvm use system</code>, or unpin the project temporarily:</p>
+    <pre><code>pvm local --unset       # remove .perl-version in current dir
+pvm use system          # now genuinely uses OS Perl</code></pre>
+    <p>Use <code>pvm current --detailed</code> to confirm which source PVM is reading from after the switch.</p>
+
     <h2>Checking the active version</h2>
     <p>To see which version PVM has resolved and why:</p>
 

--- a/reference/pvm.html
+++ b/reference/pvm.html
@@ -51,7 +51,11 @@
       </dd>
 
       <dt><code>use [version]</code></dt>
-      <dd>Activate a Perl version in the current shell session. Requires shell integration (<code>pvm init</code>).</dd>
+      <dd>
+        Activate a Perl version in the current shell session. Requires shell integration (<code>pvm init</code>).
+        <br>Accepts <code>version@library</code> to activate a named library environment alongside the Perl version (see the <a href="../guides/isolation.html">isolation guide</a>).
+        <br>Pass <code>system</code> to clear <code>PVM_PERL_VERSION</code>; note this falls through the resolution chain, so <code>.perl-version</code> files still apply (see the <a href="../guides/version-resolution.html">version resolution guide</a>).
+      </dd>
 
       <dt><code>global [version]</code></dt>
       <dd>


### PR DESCRIPTION
## Summary

Follow-up to PR #434 (merged). The alignment review of that PR against the gh-pages docs surfaced two user-facing gaps:

1. **\`pvm use system\` in a project dir** clears \`PVM_PERL_VERSION\` but the resolution chain still applies, so a \`.perl-version\` file wins and PVM picks the pinned version rather than the OS Perl. The docs previously didn't explain this.
2. **\`version@library\` syntax** (e.g., \`pvm use 5.42.0@tools\`) was only hinted at in the internal \`pvm-complete\` reference. With #434's fix porting the library-env PATH/PERL5LIB block to zsh and fish, the feature is now reliable across all three shells — worth documenting.

## Changes

- \`guides/version-resolution.html\` — added a \"Passing \`system\` to \`pvm use\`\" subsection showing how the resolution chain affects it and how to genuinely activate OS Perl from inside a project.
- \`guides/isolation.html\` — added a \"Pairing a Perl version with a library\" subsection under Named Environments showing \`pvm use version@library\`.
- \`reference/pvm.html\` — expanded the \`pvm use\` entry with one-line pointers to both guides.

## Test plan

- [x] Tag balance checked on all three edited files (opens == closes for \`<dt>\`, \`<dd>\`, \`<h3>\`).
- [ ] Reviewer: render locally or preview and confirm links resolve correctly.