### PR TITLE
feat(test,doctor): docker smoke test + detect stale pvm in PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test clean pvm pvx pm psc cross-compile
+.PHONY: all build test smoke-test clean pvm pvx pm psc cross-compile
 
 BINARIES = pvm pvx pm psc
 
@@ -20,6 +20,12 @@ psc:
 
 test:
 	go test ./... -count=1
+
+# Docker-based user-journey smoke test. Simulates a fresh install against
+# bash/zsh/fish and asserts the original #432/#433 bug scenarios stay fixed.
+# Requires docker (or a docker-compatible runtime).
+smoke-test:
+	./test/docker/smoke-test/run-smoke.sh
 
 clean:
 	rm -f $(BINARIES)

--- a/internal/pvm/doctor.go
+++ b/internal/pvm/doctor.go
@@ -499,19 +499,49 @@ func checkPathConfiguration(ui *ui.Output, issues *[]string, warnings *[]string)
 	if pvmPath, err := exec.LookPath("pvm"); err == nil {
 		ui.Success("PVM executable found in system PATH at %s", pvmPath)
 
-		// Check for additional pvm binaries in PATH — stale installs often
-		// live at /usr/local/bin/pvm or ~/.local/bin/pvm after a reinstall
-		// or version bump, and the one earlier in PATH wins. Shell
-		// integration then calls the stale binary, producing wrong-shell
-		// syntax or missing features that match the running pvm's
-		// template but not the older binary.
+		// Check for additional pvm binaries in PATH — different installs
+		// often live at /usr/local/bin/pvm and ~/.local/bin/pvm after a
+		// reinstall or version bump, and the one earlier in PATH wins.
+		// Shell integration then calls that binary, which may not match
+		// the one the user just upgraded.
+		runningPath, _ := os.Executable()
 		if stale := findStalePvmInstalls(path, pvmPath); len(stale) > 0 {
-			msg := fmt.Sprintf("Multiple pvm binaries in PATH; only %s will be used. Other copies: %s",
-				pvmPath, strings.Join(stale, ", "))
+			// Disambiguate: when the user invokes this doctor via absolute
+			// path to a newly-installed pvm, but an older copy is still
+			// first-in-PATH, say so explicitly rather than listing the
+			// running binary as "stale".
+			runningCanonical := canonicalize(runningPath)
+			runningDiffers := runningPath != "" && runningCanonical != canonicalize(pvmPath)
+
+			// Filter the running binary out of the "other copies" list when
+			// we're going to name it separately in the message.
+			others := stale
+			if runningDiffers {
+				others = others[:0]
+				for _, p := range stale {
+					if canonicalize(p) != runningCanonical {
+						others = append(others, p)
+					}
+				}
+			}
+
+			var msg string
+			if runningDiffers {
+				if len(others) == 0 {
+					msg = fmt.Sprintf("Multiple pvm binaries in PATH; shells will invoke %s, but this doctor is running from %s.",
+						pvmPath, runningPath)
+				} else {
+					msg = fmt.Sprintf("Multiple pvm binaries in PATH; shells will invoke %s, but this doctor is running from %s. Also found: %s",
+						pvmPath, runningPath, strings.Join(others, ", "))
+				}
+			} else {
+				msg = fmt.Sprintf("Multiple pvm binaries in PATH; only %s will be used. Other copies: %s",
+					pvmPath, strings.Join(others, ", "))
+			}
 			*warnings = append(*warnings, msg)
 			ui.Warning("%s", msg)
-			ui.Info("This can cause shell integration to call an older pvm than expected (e.g., 'Unknown command: unset' from fish).")
-			ui.Info("Remove the older copies or update them to match.")
+			ui.Info("This can cause shell integration to call a different pvm than expected (e.g., 'Unknown command: unset' from fish when the first-in-PATH binary predates the running fish template).")
+			ui.Info("Remove the extra copies, or adjust PATH so the intended pvm is first.")
 		}
 	} else {
 		*warnings = append(*warnings, "PVM executable not found in system PATH")

--- a/internal/pvm/doctor.go
+++ b/internal/pvm/doctor.go
@@ -498,6 +498,21 @@ func checkPathConfiguration(ui *ui.Output, issues *[]string, warnings *[]string)
 	// Check if PVM executable is in PATH
 	if pvmPath, err := exec.LookPath("pvm"); err == nil {
 		ui.Success("PVM executable found in system PATH at %s", pvmPath)
+
+		// Check for additional pvm binaries in PATH — stale installs often
+		// live at /usr/local/bin/pvm or ~/.local/bin/pvm after a reinstall
+		// or version bump, and the one earlier in PATH wins. Shell
+		// integration then calls the stale binary, producing wrong-shell
+		// syntax or missing features that match the running pvm's
+		// template but not the older binary.
+		if stale := findStalePvmInstalls(path, pvmPath); len(stale) > 0 {
+			msg := fmt.Sprintf("Multiple pvm binaries in PATH; only %s will be used. Other copies: %s",
+				pvmPath, strings.Join(stale, ", "))
+			*warnings = append(*warnings, msg)
+			ui.Warning("%s", msg)
+			ui.Info("This can cause shell integration to call an older pvm than expected (e.g., 'Unknown command: unset' from fish).")
+			ui.Info("Remove the older copies or update them to match.")
+		}
 	} else {
 		*warnings = append(*warnings, "PVM executable not found in system PATH")
 		ui.Warning("Consider adding PVM to your system PATH for easier access")

--- a/internal/pvm/doctor_path.go
+++ b/internal/pvm/doctor_path.go
@@ -1,0 +1,66 @@
+// ABOUTME: Helpers for the doctor command's PATH-related checks.
+// ABOUTME: Separated for unit-test isolation from the main diagnostic flow.
+
+package pvm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// findStalePvmInstalls scans the entries of PATH looking for pvm executables
+// beyond the one the shell resolves first. `activePath` is the canonical path
+// returned by exec.LookPath("pvm"); any additional executable named pvm
+// (or pvm.exe on Windows) on PATH is considered stale because only the
+// first-in-PATH copy is ever invoked.
+//
+// Returns an empty slice when only the active path is present or PATH is
+// empty. Entries are returned in the order they appear in PATH.
+func findStalePvmInstalls(pathEnv, activePath string) []string {
+	if pathEnv == "" {
+		return nil
+	}
+
+	binName := "pvm"
+	if runtime.GOOS == "windows" {
+		binName = "pvm.exe"
+	}
+
+	// Resolve the active path through symlinks once so we can compare
+	// canonical forms when different PATH entries point at the same file.
+	activeCanonical := canonicalize(activePath)
+
+	seen := map[string]struct{}{activeCanonical: {}}
+	var stale []string
+
+	for _, dir := range strings.Split(pathEnv, string(os.PathListSeparator)) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, binName)
+		info, err := os.Stat(candidate)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		canonical := canonicalize(candidate)
+		if _, already := seen[canonical]; already {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		stale = append(stale, candidate)
+	}
+	return stale
+}
+
+// canonicalize returns the evaluated symlink form of a path, or the input
+// path unchanged when resolution fails (e.g., permission errors on a parent
+// directory). Doctor checks should never fail because of canonicalization.
+func canonicalize(p string) string {
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return p
+	}
+	return resolved
+}

--- a/internal/pvm/doctor_path.go
+++ b/internal/pvm/doctor_path.go
@@ -12,27 +12,26 @@ import (
 
 // findStalePvmInstalls scans the entries of PATH looking for pvm executables
 // beyond the one the shell resolves first. `activePath` is the canonical path
-// returned by exec.LookPath("pvm"); any additional executable named pvm
-// (or pvm.exe on Windows) on PATH is considered stale because only the
-// first-in-PATH copy is ever invoked.
+// returned by exec.LookPath("pvm") — the binary shells will invoke. Any
+// additional pvm (or pvm.exe on Windows) on PATH is returned so the caller
+// can warn about it. Entries are returned in the order they appear in PATH.
 //
-// Returns an empty slice when only the active path is present or PATH is
-// empty. Entries are returned in the order they appear in PATH.
+// The caller is responsible for disambiguating the "running" binary
+// (os.Executable()) in the warning message — findStalePvmInstalls treats all
+// non-active copies uniformly because the doctor's job is to tell the user
+// "these extras exist"; deciding which extra is which is presentation-layer
+// work that has access to all three paths (active, running, extras).
 func findStalePvmInstalls(pathEnv, activePath string) []string {
 	if pathEnv == "" {
 		return nil
 	}
 
-	binName := "pvm"
-	if runtime.GOOS == "windows" {
-		binName = "pvm.exe"
+	binName := pvmBinaryName()
+
+	seen := map[string]struct{}{}
+	if activePath != "" {
+		seen[canonicalize(activePath)] = struct{}{}
 	}
-
-	// Resolve the active path through symlinks once so we can compare
-	// canonical forms when different PATH entries point at the same file.
-	activeCanonical := canonicalize(activePath)
-
-	seen := map[string]struct{}{activeCanonical: {}}
 	var stale []string
 
 	for _, dir := range strings.Split(pathEnv, string(os.PathListSeparator)) {
@@ -52,6 +51,16 @@ func findStalePvmInstalls(pathEnv, activePath string) []string {
 		stale = append(stale, candidate)
 	}
 	return stale
+}
+
+// pvmBinaryName returns the platform-specific executable name. Factored out
+// so tests can exercise the Windows branch on non-Windows hosts by injecting
+// the name via a parameterized helper (see doctor_path_test.go).
+func pvmBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "pvm.exe"
+	}
+	return "pvm"
 }
 
 // canonicalize returns the evaluated symlink form of a path, or the input

--- a/internal/pvm/doctor_path_test.go
+++ b/internal/pvm/doctor_path_test.go
@@ -1,0 +1,124 @@
+// ABOUTME: Unit tests for findStalePvmInstalls.
+// ABOUTME: Drives the check with a fake PATH and fabricated pvm binaries.
+
+package pvm
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestFindStalePvmInstalls(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows binary naming differs; tested manually for now")
+	}
+
+	tmp := t.TempDir()
+
+	// Build a fake two-directory layout with a pvm binary in each.
+	dirA := filepath.Join(tmp, "a")
+	dirB := filepath.Join(tmp, "b")
+	dirC := filepath.Join(tmp, "c") // empty — should be ignored
+	for _, d := range []string{dirA, dirB, dirC} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	for _, d := range []string{dirA, dirB} {
+		path := filepath.Join(d, "pvm")
+		if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+			t.Fatalf("write fake pvm in %s: %v", d, err)
+		}
+	}
+
+	cases := []struct {
+		name        string
+		pathEnv     string
+		active      string
+		wantStale   []string
+		wantNoStale bool
+	}{
+		{
+			name:      "two installs, A active",
+			pathEnv:   strings.Join([]string{dirA, dirB, dirC}, string(os.PathListSeparator)),
+			active:    filepath.Join(dirA, "pvm"),
+			wantStale: []string{filepath.Join(dirB, "pvm")},
+		},
+		{
+			name:      "two installs, B active",
+			pathEnv:   strings.Join([]string{dirA, dirB}, string(os.PathListSeparator)),
+			active:    filepath.Join(dirB, "pvm"),
+			wantStale: []string{filepath.Join(dirA, "pvm")},
+		},
+		{
+			name:        "only the active install present",
+			pathEnv:     strings.Join([]string{dirA, dirC}, string(os.PathListSeparator)),
+			active:      filepath.Join(dirA, "pvm"),
+			wantNoStale: true,
+		},
+		{
+			name:        "empty PATH",
+			pathEnv:     "",
+			active:      filepath.Join(dirA, "pvm"),
+			wantNoStale: true,
+		},
+		{
+			name:        "PATH has duplicate entries of the active dir",
+			pathEnv:     strings.Join([]string{dirA, dirA, dirC}, string(os.PathListSeparator)),
+			active:      filepath.Join(dirA, "pvm"),
+			wantNoStale: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findStalePvmInstalls(tc.pathEnv, tc.active)
+			if tc.wantNoStale {
+				if len(got) != 0 {
+					t.Errorf("expected no stale installs, got %v", got)
+				}
+				return
+			}
+			if len(got) != len(tc.wantStale) {
+				t.Fatalf("expected %d stale installs, got %d: %v", len(tc.wantStale), len(got), got)
+			}
+			for i, want := range tc.wantStale {
+				if got[i] != want {
+					t.Errorf("stale[%d]: got %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+func TestFindStalePvmInstalls_SymlinkDedup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows symlink handling differs")
+	}
+
+	tmp := t.TempDir()
+	realDir := filepath.Join(tmp, "real")
+	linkDir := filepath.Join(tmp, "link")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	realBin := filepath.Join(realDir, "pvm")
+	if err := os.WriteFile(realBin, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write pvm: %v", err)
+	}
+	if err := os.Symlink(realDir, linkDir); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// PATH contains both the real dir and the symlinked one. The pvm binary
+	// is physically the same file; findStalePvmInstalls must not flag it
+	// as stale.
+	pathEnv := strings.Join([]string{realDir, linkDir}, string(os.PathListSeparator))
+	got := findStalePvmInstalls(pathEnv, realBin)
+	if len(got) != 0 {
+		t.Errorf("expected symlinked duplicate to dedupe, got stale=%v", got)
+	}
+}

--- a/test/docker/smoke-test/Dockerfile
+++ b/test/docker/smoke-test/Dockerfile
@@ -1,0 +1,37 @@
+# Smoke-test container: simulates a fresh user system with bash, zsh, and
+# fish installed alongside a minimal Perl toolchain. Accepts a pre-built pvm
+# binary via COPY. No Go toolchain — this is NOT a unit-test container, it
+# tests the user-facing journey against a release-style binary.
+#
+# Build + run is driven by ./run-smoke.sh from the repo root.
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        zsh \
+        fish \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Put pvm where fresh-install instructions tell users to put it.
+# /usr/local/bin is on the default Debian PATH for bash, zsh, and fish.
+COPY pvm /usr/local/bin/pvm
+RUN chmod +x /usr/local/bin/pvm
+
+# Per-shell journey scripts exercise the user-reported bug scenarios.
+COPY journeys /smoke/journeys
+
+# Offline-safe: MetaCPAN isn't reachable from CI in many environments and
+# we don't need it for the smoke test (no real Perl installs happen).
+ENV PVM_SKIP_NETWORK_CALLS=1
+
+# Give each run its own scratch XDG dirs — mimics a fresh user account.
+ENV HOME=/root \
+    XDG_CONFIG_HOME=/root/.config \
+    XDG_DATA_HOME=/root/.local/share \
+    XDG_CACHE_HOME=/root/.cache \
+    XDG_STATE_HOME=/root/.local/state
+
+WORKDIR /smoke

--- a/test/docker/smoke-test/README.md
+++ b/test/docker/smoke-test/README.md
@@ -1,0 +1,56 @@
+# Smoke-test container
+
+Exercises the real user-facing journey against a fresh-install PVM on a
+Debian-based system with bash, zsh, and fish available. Asserts the two
+originally-reported bug scenarios stay fixed:
+
+1. **`pvm local` / `pvm global` are top-level commands** (issue #432).
+2. **`pvm use X` actually changes the active `perl`** — PATH refresh works,
+   `PVM_PERL_VERSION` exports, and `perl -v` reflects the new version in
+   the same shell (issue #433). Also exits non-zero for bogus versions.
+
+Fish gets extra assertions covering the bugs uncovered during PR #434
+development: no fish parse errors in the templates, completions actually
+register after `pvm init fish | source`.
+
+## Running
+
+From the repo root, with Docker or a Docker-compatible runtime (podman works
+if aliased) installed:
+
+```sh
+./test/docker/smoke-test/run-smoke.sh
+```
+
+The script builds a Linux `pvm` binary, bakes it into the image, then runs
+one container invocation per shell. Each journey is a self-contained script
+under `journeys/`; a failure is visible as a `[SMOKE FAIL]` marker in the
+output and exits non-zero.
+
+## Layout
+
+- `Dockerfile` — minimal Debian image with bash/zsh/fish + the pvm binary.
+  No Go toolchain; this is a user-journey test, not a unit-test container.
+- `journeys/common.sh` / `common.fish` — assertion helpers.
+- `journeys/bash-journey.sh` / `zsh-journey.sh` / `fish-journey.fish` —
+  per-shell journey scripts. Each sources `pvm init $shell`, runs real
+  user commands, and asserts observable behavior.
+- `run-smoke.sh` — orchestration (build + run + aggregate).
+
+## Relationship to the shell-integration test container
+
+`../shell-integration/Dockerfile` runs the Go e2e test suite in a container.
+It's a *CI-parity* check — the tests themselves live in `test/e2e/`.
+
+This smoke-test container is different: it has no Go toolchain and does
+not run `go test`. It runs the same commands a real user types, and asserts
+on the shell output. If a future change to the templates or the `pvm`
+binary breaks the user-visible contract, this catches it even if the
+unit-test env (which uses the built-in-test `env.PVMBinary`) misses it
+because a stale `pvm` in PATH shadows the fresh build.
+
+## Offline
+
+The image runs with `PVM_SKIP_NETWORK_CALLS=1` set by default — the smoke
+test does not reach MetaCPAN or any other external service. It's safe to
+run in CI environments with no internet access.

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# ABOUTME: Bash user journey smoke test. Runs inside the smoke-test container.
+# ABOUTME: Exercises the two user-reported bug scenarios (#432 local/global,
+#          #433 pvm use PATH refresh) plus the full activation flow.
+
+set -u
+source "$(dirname "$0")/common.sh"
+
+echo "=== bash smoke test ==="
+
+# --- issue #432: pvm local must exist at top level --------------------------
+local_help=$(pvm local --help 2>&1)
+smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+
+global_help=$(pvm global --help 2>&1)
+smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+
+use_help=$(pvm --help 2>&1)
+smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+
+# --- prerequisite: import system perl, fake a version dir -------------------
+pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
+
+VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
+
+mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
+# Minimal stub perl so `perl -v` works
+cat > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl" <<EOF
+#!/bin/sh
+echo "This is perl 5, version ${VERSION#5.}, subversion 0 (v$VERSION) stub"
+EOF
+chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+
+# --- issue #433 core: source integration, pvm use, PATH changes -------------
+# shellcheck disable=SC1090
+source <(pvm init bash)
+
+pvm use "$VERSION" 2>&1 | grep -q "Using Perl $VERSION" \
+    || smoke_fail "pvm use did not print 'Using Perl $VERSION'"
+smoke_pass "pvm use prints Using Perl"
+
+smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+
+front=$(echo "$PATH" | cut -d: -f1)
+smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+    "version bin at front of PATH after pvm use"
+
+perl_out=$(perl -v 2>&1 | head -1)
+smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+
+# --- issue #433 I1: bogus version must exit non-zero ------------------------
+pvm use not-a-real-version >/dev/null 2>&1
+rc=$?
+smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+
+# --- shell integration contract: 'pvm use' is usable via 'A && B' -----------
+if pvm use not-a-real-version 2>/dev/null; then
+    smoke_fail "pvm use <bogus> followed by && should NOT run the next command"
+else
+    smoke_pass "pvm use <bogus> short-circuits && chains"
+fi
+
+echo ""
+echo "=== bash smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -24,13 +24,7 @@ pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
 [ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
 
-mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
-# Minimal stub perl so `perl -v` works
-cat > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl" <<EOF
-#!/bin/sh
-echo "This is perl 5, version ${VERSION#5.}, subversion 0 (v$VERSION) stub"
-EOF
-chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+smoke_setup_stub_perl "$VERSION"
 
 # --- issue #433 core: source integration, pvm use, PATH changes -------------
 # shellcheck disable=SC1090

--- a/test/docker/smoke-test/journeys/common.fish
+++ b/test/docker/smoke-test/journeys/common.fish
@@ -46,3 +46,21 @@ function smoke_exit_eq
         smoke_fail "$label: expected exit $expected, got $actual"
     end
 end
+
+# Create a stub perl executable under $XDG_DATA_HOME/pvm/versions/$1/bin/perl
+# whose `perl -v` output matches the canonical real-perl shape. Emit three
+# integers for major/minor/patch so any future regex-based parser finds the
+# right components. NB: fish has a read-only $version referring to its own
+# version, so we use $requested_version for the argument.
+function smoke_setup_stub_perl
+    set -l requested_version $argv[1]
+    set -l bin_dir "$XDG_DATA_HOME/pvm/versions/$requested_version/bin"
+    set -l parts (string split . -- $requested_version)
+    set -l major $parts[1]
+    set -l minor $parts[2]
+    set -l patch $parts[3]
+    mkdir -p "$bin_dir"
+    printf '#!/bin/sh\necho "This is perl %s, version %s, subversion %s (v%s) stub"\n' \
+        $major $minor $patch $requested_version > "$bin_dir/perl"
+    chmod +x "$bin_dir/perl"
+end

--- a/test/docker/smoke-test/journeys/common.fish
+++ b/test/docker/smoke-test/journeys/common.fish
@@ -1,0 +1,48 @@
+# ABOUTME: Shared smoke-test helpers for the fish journey script.
+# ABOUTME: Mirrors journeys/common.sh in intent; fish has no `set -u` equivalent.
+
+function smoke_fail
+    printf '\n[SMOKE FAIL] %s\n' $argv >&2
+    exit 1
+end
+
+function smoke_pass
+    printf '[SMOKE PASS] %s\n' $argv
+end
+
+# Assert a string contains a substring.
+# Usage: smoke_contains ACTUAL EXPECTED LABEL
+function smoke_contains
+    set -l actual $argv[1]
+    set -l expected $argv[2]
+    set -l label $argv[3]
+    if string match -q "*$expected*" -- $actual
+        smoke_pass $label
+    else
+        smoke_fail "$label: expected to contain [$expected], got [$actual]"
+    end
+end
+
+# Assert two strings are equal.
+function smoke_equals
+    set -l actual $argv[1]
+    set -l expected $argv[2]
+    set -l label $argv[3]
+    if test "$actual" = "$expected"
+        smoke_pass $label
+    else
+        smoke_fail "$label: expected [$expected], got [$actual]"
+    end
+end
+
+# Assert an exit code.
+function smoke_exit_eq
+    set -l actual $argv[1]
+    set -l expected $argv[2]
+    set -l label $argv[3]
+    if test "$actual" = "$expected"
+        smoke_pass "$label (exit=$actual)"
+    else
+        smoke_fail "$label: expected exit $expected, got $actual"
+    end
+end

--- a/test/docker/smoke-test/journeys/common.sh
+++ b/test/docker/smoke-test/journeys/common.sh
@@ -44,3 +44,21 @@ smoke_exit_eq() {
         smoke_fail "$label: expected exit $expected, got $actual"
     fi
 }
+
+# Create a stub perl executable under $XDG_DATA_HOME/pvm/versions/$1/bin/perl
+# whose `perl -v` output matches the canonical real-perl shape. Emit three
+# integers for major/minor/patch so any future regex-based parser finds the
+# right components (real perl prints "version N, subversion M", not
+# "version N.M, subversion 0").
+smoke_setup_stub_perl() {
+    local version="$1"
+    local bin_dir="$XDG_DATA_HOME/pvm/versions/$version/bin"
+    local major minor patch
+    IFS=. read -r major minor patch <<< "$version"
+    mkdir -p "$bin_dir"
+    cat > "$bin_dir/perl" <<EOF
+#!/bin/sh
+echo "This is perl $major, version $minor, subversion $patch (v$version) stub"
+EOF
+    chmod +x "$bin_dir/perl"
+}

--- a/test/docker/smoke-test/journeys/common.sh
+++ b/test/docker/smoke-test/journeys/common.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ABOUTME: Shared smoke-test helpers loaded by per-shell journey scripts.
+# ABOUTME: POSIX-ish so it works from bash / zsh wrapper scripts; fish loads
+#          its own equivalent in journeys/common.fish.
+
+set -u
+
+# Exit with a visible marker any test harness can grep for.
+smoke_fail() {
+    printf '\n[SMOKE FAIL] %s\n' "$*" >&2
+    exit 1
+}
+
+smoke_pass() {
+    printf '[SMOKE PASS] %s\n' "$*"
+}
+
+# Assert a string contains a substring. First arg is the actual value, second
+# is the expected substring, third is a human-readable label.
+smoke_contains() {
+    local actual="$1" expected="$2" label="$3"
+    case "$actual" in
+        *"$expected"*) smoke_pass "$label" ;;
+        *) smoke_fail "$label: expected to contain [$expected], got [$actual]" ;;
+    esac
+}
+
+# Assert two strings are equal.
+smoke_equals() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "$actual" = "$expected" ]; then
+        smoke_pass "$label"
+    else
+        smoke_fail "$label: expected [$expected], got [$actual]"
+    fi
+}
+
+# Assert an exit code.
+smoke_exit_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [ "$actual" = "$expected" ]; then
+        smoke_pass "$label (exit=$actual)"
+    else
+        smoke_fail "$label: expected exit $expected, got $actual"
+    fi
+}

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -1,0 +1,67 @@
+#!/usr/bin/env fish
+# ABOUTME: Fish user journey smoke test. Runs inside the smoke-test container.
+# ABOUTME: Mirrors bash-journey.sh using fish idioms; especially valuable since
+#          fish uncovered multiple template bugs during PR #434 development.
+
+source (dirname (status -f))/common.fish
+
+echo "=== fish smoke test ==="
+
+# Top-level commands exist
+set -l local_help (pvm local --help 2>&1 | string collect)
+smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+
+set -l global_help (pvm global --help 2>&1 | string collect)
+smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+
+# Import system perl + fake version dir
+pvm import-system >/dev/null 2>&1
+or smoke_fail "import-system failed"
+
+set -l VERSION (pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | head -1)
+test -n "$VERSION"
+or smoke_fail "no Perl version found after import-system"
+
+mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
+printf '#!/bin/sh\necho "This is perl 5, version %s, subversion 0 (v%s) stub"\n' \
+    (string replace '5.' '' $VERSION) $VERSION \
+    > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+
+# Source pvm init — must not error
+pvm init fish | source
+or smoke_fail "sourcing pvm init fish failed"
+smoke_pass "sourced pvm init fish cleanly"
+
+# Run pvm use; capture output AND stderr to catch template errors
+set -l use_out (pvm use "$VERSION" 2>&1 | string collect)
+smoke_contains "$use_out" "Using Perl $VERSION" "pvm use prints Using Perl"
+# No stray 'Unknown command: unset' or similar fish-parse errors
+if string match -q "*Unknown command*" -- $use_out
+    smoke_fail "pvm use produced a fish parse error: $use_out"
+end
+smoke_pass "pvm use output is fish-clean (no Unknown command errors)"
+
+smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+
+set -l front (string split : -- $PATH | head -1)
+smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+    "version bin at front of PATH after pvm use"
+
+set -l perl_out (perl -v 2>&1 | head -1 | string collect)
+smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+
+# Bogus version must exit non-zero (tests $pipestatus[1] plumbing)
+pvm use not-a-real-version >/dev/null 2>&1
+set -l rc $status
+smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+
+# Completion must actually register (C2 regression)
+set -l pvm_completions (complete -c pvm 2>/dev/null | count)
+if test $pvm_completions -lt 5
+    smoke_fail "fish completions did not register (found $pvm_completions rules)"
+end
+smoke_pass "fish completions registered ($pvm_completions rules)"
+
+echo ""
+echo "=== fish smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -14,6 +14,9 @@ smoke_contains "$local_help" "local [version]" "pvm local is a top-level command
 set -l global_help (pvm global --help 2>&1 | string collect)
 smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
 
+set -l use_help (pvm --help 2>&1 | string collect)
+smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+
 # Import system perl + fake version dir
 pvm import-system >/dev/null 2>&1
 or smoke_fail "import-system failed"
@@ -22,11 +25,7 @@ set -l VERSION (pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | 
 test -n "$VERSION"
 or smoke_fail "no Perl version found after import-system"
 
-mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
-printf '#!/bin/sh\necho "This is perl 5, version %s, subversion 0 (v%s) stub"\n' \
-    (string replace '5.' '' $VERSION) $VERSION \
-    > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
-chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+smoke_setup_stub_perl "$VERSION"
 
 # Source pvm init — must not error
 pvm init fish | source
@@ -55,6 +54,12 @@ smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
 pvm use not-a-real-version >/dev/null 2>&1
 set -l rc $status
 smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+
+# Shell-level contract: `pvm use <bogus>; and ...` must short-circuit
+# (fish uses `; and` where POSIX uses `&&`).
+pvm use not-a-real-version 2>/dev/null
+and smoke_fail "pvm use <bogus> followed by `; and` should NOT run the next command"
+smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 
 # Completion must actually register (C2 regression)
 set -l pvm_completions (complete -c pvm 2>/dev/null | count)

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -13,17 +13,15 @@ smoke_contains "$local_help" "local [version]" "pvm local is a top-level command
 global_help=$(pvm global --help 2>&1)
 smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
 
+use_help=$(pvm --help 2>&1)
+smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 
 VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
 [ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
 
-mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
-cat > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl" <<EOF
-#!/bin/sh
-echo "This is perl 5, version ${VERSION#5.}, subversion 0 (v$VERSION) stub"
-EOF
-chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+smoke_setup_stub_perl "$VERSION"
 
 # shellcheck disable=SC1090
 source <(pvm init zsh)
@@ -44,6 +42,13 @@ smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
 pvm use not-a-real-version >/dev/null 2>&1
 rc=$?
 smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+
+# Shell-level contract: `pvm use <bogus>` must short-circuit an && chain.
+if pvm use not-a-real-version 2>/dev/null; then
+    smoke_fail "pvm use <bogus> followed by && should NOT run the next command"
+else
+    smoke_pass "pvm use <bogus> short-circuits && chains"
+fi
 
 echo ""
 echo "=== zsh smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env zsh
+# ABOUTME: Zsh user journey smoke test. Runs inside the smoke-test container.
+# ABOUTME: Mirrors bash-journey.sh with zsh-specific sourcing.
+
+set -u
+source "$(dirname "$0")/common.sh"
+
+echo "=== zsh smoke test ==="
+
+local_help=$(pvm local --help 2>&1)
+smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+
+global_help=$(pvm global --help 2>&1)
+smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+
+pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
+
+VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
+
+mkdir -p "$XDG_DATA_HOME/pvm/versions/$VERSION/bin"
+cat > "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl" <<EOF
+#!/bin/sh
+echo "This is perl 5, version ${VERSION#5.}, subversion 0 (v$VERSION) stub"
+EOF
+chmod +x "$XDG_DATA_HOME/pvm/versions/$VERSION/bin/perl"
+
+# shellcheck disable=SC1090
+source <(pvm init zsh)
+
+pvm use "$VERSION" 2>&1 | grep -q "Using Perl $VERSION" \
+    || smoke_fail "pvm use did not print 'Using Perl $VERSION'"
+smoke_pass "pvm use prints Using Perl"
+
+smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+
+front=$(echo "$PATH" | cut -d: -f1)
+smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+    "version bin at front of PATH after pvm use"
+
+perl_out=$(perl -v 2>&1 | head -1)
+smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+
+pvm use not-a-real-version >/dev/null 2>&1
+rc=$?
+smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+
+echo ""
+echo "=== zsh smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/run-smoke.sh
+++ b/test/docker/smoke-test/run-smoke.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# ABOUTME: Build the smoke-test image and run the three shell journeys
+# ABOUTME: (bash, zsh, fish). Fails if any shell's journey fails.
+
+set -eu
+
+here="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$here/../../.." && pwd)"
+
+cd "$repo_root"
+
+echo "==> Building pvm binary for the smoke-test image"
+mkdir -p "$here/build"
+(
+    cd "$repo_root"
+    # Build for Linux since the container runs Debian.
+    GOOS=linux GOARCH=amd64 go build -o "$here/build/pvm" ./cmd/pvm/
+)
+
+echo "==> Building smoke-test container"
+# Copy the binary next to the Dockerfile so the build context is minimal.
+cp "$here/build/pvm" "$here/pvm"
+trap 'rm -f "$here/pvm"' EXIT
+docker build -t pvm-smoke:latest "$here"
+
+echo ""
+failures=0
+for shell_script in bash:bash-journey.sh zsh:zsh-journey.sh fish:fish-journey.fish; do
+    shell="${shell_script%%:*}"
+    script="${shell_script#*:}"
+    echo "==> Running $shell journey"
+    if docker run --rm pvm-smoke:latest "$shell" "/smoke/journeys/$script"; then
+        echo "   ✓ $shell journey passed"
+    else
+        echo "   ✗ $shell journey FAILED"
+        failures=$((failures + 1))
+    fi
+    echo ""
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo "==> $failures shell journey(s) failed"
+    exit 1
+fi
+
+echo "==> All shell journeys passed"

--- a/test/docker/smoke-test/run-smoke.sh
+++ b/test/docker/smoke-test/run-smoke.sh
@@ -13,8 +13,10 @@ echo "==> Building pvm binary for the smoke-test image"
 mkdir -p "$here/build"
 (
     cd "$repo_root"
-    # Build for Linux since the container runs Debian.
-    GOOS=linux GOARCH=amd64 go build -o "$here/build/pvm" ./cmd/pvm/
+    # Build for Linux since the container runs Debian. CGO_ENABLED=0 matches
+    # the Makefile's cross-compile convention and guarantees the binary runs
+    # regardless of the host's libc.
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "$here/build/pvm" ./cmd/pvm/
 )
 
 echo "==> Building smoke-test container"


### PR DESCRIPTION
## Summary

Follow-up to PR #434. Two preventive additions informed by pitfalls
encountered during that PR's development.

### Docker smoke-test container

\`test/docker/smoke-test/\` — simulates a fresh user system with bash, zsh,
and fish alongside a pre-built pvm binary. Unlike
\`test/docker/shell-integration/\` (which runs the Go e2e suite in a
container), this one has NO Go toolchain. The per-shell journey scripts
execute the exact commands the bug reporter would type:

\`\`\`
pvm local --help
pvm global --help
source <(pvm init \$SHELL)
pvm use \$VERSION
perl -v                      # original #433 user-visible check
pvm use not-a-real-version   # exit-code regression guard
\`\`\`

Fish adds completions-registered and "no Unknown command errors" assertions
specifically for the bugs that surfaced during PR #434.

Run with \`make smoke-test\` (requires docker). Offline-safe.

### pvm self doctor: stale-install detection

When multiple \`pvm\` binaries live in PATH (common after reinstalls, or
after Homebrew-over-manual installs), only the first-in-PATH copy is used.
Shell integration then calls a stale binary whose output doesn't match
what the running pvm's templates expect — which is exactly the
"Unknown command: unset" error from fish we saw during PR #434 on my
own machine, because \`/home/perigrin/.local/bin/pvm\` shadowed
\`/tmp/pvm-test\`.

New \`findStalePvmInstalls\` helper (\`internal/pvm/doctor_path.go\`)
scans PATH beyond the first-in-PATH entry. When it finds additional
\`pvm\` binaries, \`checkPathConfiguration\` emits a warning that names
the fish symptom explicitly and points at remediation. Unit tests cover
two-install ordering, symlinked-duplicate dedup, empty PATH, and
duplicate PATH entries of the active dir.

## Test plan

- [x] New unit tests in \`internal/pvm/doctor_path_test.go\` pass (6 cases).
- [x] Manual verification: \`pvm self doctor\` with \`/tmp/stale/pvm\` +
  \`/tmp/fresh/pvm\` both in PATH warns about the extra copy.
- [ ] Reviewer: run \`make smoke-test\` on a machine with Docker installed.
- [ ] Optional: add a CI workflow that runs \`make smoke-test\` on PRs.