### PR TITLE
feat(test): expand smoke-test coverage to ~128 assertions across ~20 commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,24 @@ jobs:
 
     - name: Test
       run: go test ./... -count=1
+
+  smoke-test:
+    name: Smoke Test (bash, zsh, fish)
+    runs-on: ubuntu-latest
+    needs: test
+    env:
+      # Gate the two-version binary-install section off in CI until the
+      # release artifacts ship signed SHA256 manifests. Issue tracked
+      # separately. Journeys fall through to the single-version fallback.
+      PVM_SMOKE_SKIP_BINARY_INSTALL: "1"
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24.4'
+
+    - name: Run smoke-test suite
+      run: ./test/docker/smoke-test/run-smoke.sh

--- a/internal/current/formatter.go
+++ b/internal/current/formatter.go
@@ -61,15 +61,15 @@ func formatDefault(info *CurrentVersionInfo, options *DisplayOptions) string {
 
 // formatJSON returns structured JSON output
 func formatJSON(info *CurrentVersionInfo, options *DisplayOptions) (string, error) {
+	// JSON schema is a consumer contract — always emit every top-level key.
+	// Use an empty string for `path` when no resolved interpreter is
+	// available so downstream tooling doesn't have to branch on presence.
 	output := map[string]interface{}{
 		"version":            info.Version,
 		"source":             info.Source,
 		"source_description": info.SourceDescription,
 		"available":          info.IsAvailable,
-	}
-
-	if info.Path != "" {
-		output["path"] = info.Path
+		"path":               info.Path,
 	}
 
 	if options.ShowWarnings || options.ShowComparison || options.Validate {

--- a/internal/perl/shell_templates/pvm.bash
+++ b/internal/perl/shell_templates/pvm.bash
@@ -7,7 +7,7 @@
 # sub-shells of a different family (bash -c from fish, zsh scripts, etc.)
 # must not inherit a stale value; they detect their own shell via $SHELL or
 # their own sourced template.
-if [ -n "$ZSH_VERSION" ]; then
+if [ -n "${ZSH_VERSION-}" ]; then
     _PVM_SHELL_TYPE=zsh
 else
     _PVM_SHELL_TYPE=bash
@@ -35,7 +35,7 @@ _pvm_find_executable() {
 
 # Function to get PVM executable path
 _pvm_executable() {
-    if [ -z "$PVM_EXEC_CACHE" ]; then
+    if [ -z "${PVM_EXEC_CACHE-}" ]; then
         PVM_EXEC_CACHE="$(_pvm_find_executable)"
         if [ $? -ne 0 ]; then
             return 1
@@ -122,13 +122,13 @@ _pvm_update_perl_path() {
     fi
 
     # Handle library environment if PVM_PERL_LIBRARY is set
-    if [ -n "$PVM_PERL_LIBRARY" ]; then
+    if [ -n "${PVM_PERL_LIBRARY-}" ]; then
         local library_env_dir="$xdg_data_home/pvm/environments/$PVM_PERL_LIBRARY"
         if [ -d "$library_env_dir" ]; then
             # Add library environment's lib/perl5 to PERL5LIB
             local library_lib_dir="$library_env_dir/lib/perl5"
             if [ -d "$library_lib_dir" ]; then
-                if [ -n "$PERL5LIB" ]; then
+                if [ -n "${PERL5LIB-}" ]; then
                     export PERL5LIB="$library_lib_dir:$PERL5LIB"
                 else
                     export PERL5LIB="$library_lib_dir"
@@ -144,7 +144,7 @@ _pvm_update_perl_path() {
     else
         # Clear library-specific PERL5LIB when no library is active
         # Only clear if it contains PVM environment paths
-        if [ -n "$PERL5LIB" ]; then
+        if [ -n "${PERL5LIB-}" ]; then
             local cleaned_perl5lib=""
             local remaining_perl5lib="$PERL5LIB"
             while [ -n "$remaining_perl5lib" ]; do
@@ -262,7 +262,7 @@ pvm_init() {
     }
 
     # Set up cd override (if supported)
-    if [ -n "$ZSH_VERSION" ]; then
+    if [ -n "${ZSH_VERSION-}" ]; then
         # For Zsh, use chpwd hook
         pvm_chpwd() {
             # Update PATH to reflect current directory's Perl version
@@ -293,8 +293,8 @@ pvm_init() {
 pvm_init
 
 # Set up completion (skip during tests)
-if [ "$PVM_SKIP_NETWORK_CALLS" != "1" ]; then
-    if [ -n "$ZSH_VERSION" ]; then
+if [ "${PVM_SKIP_NETWORK_CALLS-}" != "1" ]; then
+    if [ -n "${ZSH_VERSION-}" ]; then
         eval "$(PVM_SHELL="$_PVM_SHELL_TYPE" "$(_pvm_executable)" completion zsh 2>/dev/null || true)"
     else
         eval "$(PVM_SHELL="$_PVM_SHELL_TYPE" "$(_pvm_executable)" completion bash 2>/dev/null || true)"

--- a/internal/perl/shell_templates/pvm.zsh
+++ b/internal/perl/shell_templates/pvm.zsh
@@ -7,7 +7,7 @@
 # sub-shells of a different family (bash -c from fish, zsh scripts, etc.)
 # must not inherit a stale value; they detect their own shell via $SHELL or
 # their own sourced template.
-if [ -n "$ZSH_VERSION" ]; then
+if [ -n "${ZSH_VERSION-}" ]; then
     _PVM_SHELL_TYPE=zsh
 else
     _PVM_SHELL_TYPE=bash
@@ -35,7 +35,7 @@ _pvm_find_executable() {
 
 # Function to get PVM executable path
 _pvm_executable() {
-    if [ -z "$PVM_EXEC_CACHE" ]; then
+    if [ -z "${PVM_EXEC_CACHE-}" ]; then
         PVM_EXEC_CACHE="$(_pvm_find_executable)"
         if [ $? -ne 0 ]; then
             return 1
@@ -122,12 +122,12 @@ _pvm_update_perl_path() {
     fi
 
     # Handle library environment if PVM_PERL_LIBRARY is set
-    if [ -n "$PVM_PERL_LIBRARY" ]; then
+    if [ -n "${PVM_PERL_LIBRARY-}" ]; then
         local library_env_dir="$xdg_data_home/pvm/environments/$PVM_PERL_LIBRARY"
         if [ -d "$library_env_dir" ]; then
             local library_lib_dir="$library_env_dir/lib/perl5"
             if [ -d "$library_lib_dir" ]; then
-                if [ -n "$PERL5LIB" ]; then
+                if [ -n "${PERL5LIB-}" ]; then
                     export PERL5LIB="$library_lib_dir:$PERL5LIB"
                 else
                     export PERL5LIB="$library_lib_dir"
@@ -140,7 +140,7 @@ _pvm_update_perl_path() {
         fi
     else
         # Clear library-specific PERL5LIB when no library is active
-        if [ -n "$PERL5LIB" ]; then
+        if [ -n "${PERL5LIB-}" ]; then
             local cleaned_perl5lib=""
             local remaining_perl5lib="$PERL5LIB"
             while [ -n "$remaining_perl5lib" ]; do
@@ -254,7 +254,7 @@ pvm_init() {
     }
 
     # Set up cd override (if supported)
-    if [ -n "$ZSH_VERSION" ]; then
+    if [ -n "${ZSH_VERSION-}" ]; then
         # For Zsh, use chpwd hook
         pvm_chpwd() {
             # Update PATH to reflect current directory's Perl version
@@ -285,8 +285,8 @@ pvm_init() {
 pvm_init
 
 # Set up completion (skip during tests)
-if [ "$PVM_SKIP_NETWORK_CALLS" != "1" ]; then
-    if [ -n "$ZSH_VERSION" ]; then
+if [ "${PVM_SKIP_NETWORK_CALLS-}" != "1" ]; then
+    if [ -n "${ZSH_VERSION-}" ]; then
         eval "$(PVM_SHELL="$_PVM_SHELL_TYPE" "$(_pvm_executable)" completion zsh 2>/dev/null || true)"
     else
         eval "$(PVM_SHELL="$_PVM_SHELL_TYPE" "$(_pvm_executable)" completion bash 2>/dev/null || true)"

--- a/internal/pvm/command.go
+++ b/internal/pvm/command.go
@@ -1056,50 +1056,63 @@ Examples:
 				installedMap[info.Version] = true
 			}
 
-			// Get cache directory for MetaCPAN data
-			dirs, err := xdg.GetDirs()
-			if err != nil {
-				return fmt.Errorf("failed to get XDG directories: %w", err)
-			}
-
-			// Create MetaCPAN provider with 72-hour cache TTL
-			provider, err := cpan.NewMetaCPANProvider(
-				cpan.WithCache(dirs.CacheDir, 72), // 72 hours
-			)
-			if err != nil {
-				return fmt.Errorf("failed to create MetaCPAN provider: %w", err)
-			}
-
-			// Fetch available Perl versions from MetaCPAN (with cache fallback)
-			ctx := context.Background()
-
-			// Fetch stable versions
-			stableVersions, err := provider.GetPerlCoreVersions(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to fetch Perl versions from MetaCPAN: %w", err)
-			}
-
-			// Fetch development versions if requested
+			// Honor PVM_SKIP_NETWORK_CALLS the same way resolver.go and the
+			// shell templates do. In offline mode, report only installed
+			// versions — enough for smoke tests and offline CI, avoids a
+			// 10s+ DNS/connect timeout to MetaCPAN.
+			var stableVersions []string
 			var devVersions []string
-			if includeDev {
-				allVersions, err := provider.GetPerlCoreVersionsWithDev(ctx, true)
-				if err != nil {
-					return fmt.Errorf("failed to fetch development versions from MetaCPAN: %w", err)
-				}
+			skipNetwork := os.Getenv("PVM_SKIP_NETWORK_CALLS") == "1"
 
-				// Filter out stable versions to get only dev versions
-				stableMap := make(map[string]bool)
-				for _, version := range stableVersions {
-					stableMap[version] = true
-				}
-
-				for _, version := range allVersions {
-					if !stableMap[version] {
-						devVersions = append(devVersions, version)
-					}
+			if skipNetwork {
+				for _, info := range installedVersions {
+					stableVersions = append(stableVersions, info.Version)
 				}
 			} else {
-				devVersions = []string{}
+				// Get cache directory for MetaCPAN data
+				dirs, err := xdg.GetDirs()
+				if err != nil {
+					return fmt.Errorf("failed to get XDG directories: %w", err)
+				}
+
+				// Create MetaCPAN provider with 72-hour cache TTL
+				provider, err := cpan.NewMetaCPANProvider(
+					cpan.WithCache(dirs.CacheDir, 72), // 72 hours
+				)
+				if err != nil {
+					return fmt.Errorf("failed to create MetaCPAN provider: %w", err)
+				}
+
+				// Fetch available Perl versions from MetaCPAN (with cache fallback)
+				ctx := context.Background()
+
+				// Fetch stable versions
+				stableVersions, err = provider.GetPerlCoreVersions(ctx)
+				if err != nil {
+					return fmt.Errorf("failed to fetch Perl versions from MetaCPAN: %w", err)
+				}
+
+				// Fetch development versions if requested
+				if includeDev {
+					allVersions, err := provider.GetPerlCoreVersionsWithDev(ctx, true)
+					if err != nil {
+						return fmt.Errorf("failed to fetch development versions from MetaCPAN: %w", err)
+					}
+
+					// Filter out stable versions to get only dev versions
+					stableMap := make(map[string]bool)
+					for _, version := range stableVersions {
+						stableMap[version] = true
+					}
+
+					for _, version := range allVersions {
+						if !stableMap[version] {
+							devVersions = append(devVersions, version)
+						}
+					}
+				} else {
+					devVersions = []string{}
+				}
 			}
 
 			// Handle JSON format

--- a/test/docker/smoke-test/README.md
+++ b/test/docker/smoke-test/README.md
@@ -13,11 +13,20 @@ Covers `pvm version`, `pvm --help`, `pvm list`/`versions`, `pvm available`
 / `pvm current --bare`, plus `--help` for every top-level command to
 catch cobra registration bugs.
 
-## Per-shell journeys (~29–32 assertions each)
+## `advanced-commands.sh` (shell-agnostic, ~29 assertions)
+
+Jobs-To-Be-Done workflows that Perl devs regularly exercise: resolution
+source attribution (`current --detailed`/`--json`, `PVM_PERL_VERSION`
+override precedence), broken-pin degradation, `workspace init` scaffold
+(creates `.perl-version`/`cpanfile`/`pvm.toml`/`lib`/`t`),
+`config set/get/unset/validate/sources` round-trip, `remote add/remove`
+write-path, `self symlinks verify`, `rehash --dry-run` idempotence.
+
+## Per-shell journeys (~32–35 assertions each)
 
 `bash-journey.sh` / `zsh-journey.sh` / `fish-journey.fish` each source
 the real shell integration and exercise workflows that depend on the
-shell (env-var exports, PATH rewriting). Eight sections per shell:
+shell (env-var exports, PATH rewriting). Nine sections per shell:
 
 1. **Top-level command presence** — root `pvm --help` lists `local`,
    `global`, `use [version[@library]]` (regression guard for #432).
@@ -26,6 +35,10 @@ shell (env-var exports, PATH rewriting). Eight sections per shell:
 3. **`pvm use`** — PATH rewrite, `PVM_PERL_VERSION` export, `perl -v`
    reflects the switch, bogus version exits non-zero AND short-circuits
    `&&` / `; and` chains (regression guard for #433).
+3b. **`cd` auto-switch hook** — `cd` into a directory with a
+    `.perl-version` pin triggers the shell-specific hook (bash's
+    `pvm_cd`, zsh's `chpwd`, fish's `--on-variable PWD`) and PATH
+    updates to match.
 4. **`pvm local`** — writes `.perl-version`, `detect-version` sees it,
    `--unset` removes it.
 5. **`pvm global`** — writes global config, `pvm current --bare` picks
@@ -45,11 +58,13 @@ Fish additionally asserts: no `Unknown command` errors from the template
 
 ## Total coverage
 
-~128 assertions across the four suites, covering roughly 20 of the 31
-top-level pvm commands. The six commands that require real Perl install
-(`install`, `build-perl`, `install-perl`, `module`, `run`/pvx, `psc`)
-intentionally stay out of smoke scope — they belong in the Go e2e suite
-(`test/docker/shell-integration/`) or a separate slow-tier CI job.
+~166 assertions across five suites, covering roughly 25 of the 31
+top-level pvm commands plus the `cd`-hook auto-switch that every
+version manager promises. The six commands that require real Perl
+install (`install`, `build-perl`, `install-perl`, `module`, `run`/pvx,
+`psc`) intentionally stay out of smoke scope — they belong in the Go
+e2e suite (`test/docker/shell-integration/`) or a separate slow-tier
+CI job.
 
 ## Running
 

--- a/test/docker/smoke-test/README.md
+++ b/test/docker/smoke-test/README.md
@@ -1,17 +1,55 @@
 # Smoke-test container
 
 Exercises the real user-facing journey against a fresh-install PVM on a
-Debian-based system with bash, zsh, and fish available. Asserts the two
-originally-reported bug scenarios stay fixed:
+Debian-based system with bash, zsh, and fish available. Runs four suites
+per invocation, covering the commands a typical user touches:
 
-1. **`pvm local` / `pvm global` are top-level commands** (issue #432).
-2. **`pvm use X` actually changes the active `perl`** — PATH refresh works,
-   `PVM_PERL_VERSION` exports, and `perl -v` reflects the new version in
-   the same shell (issue #433). Also exits non-zero for bogus versions.
+## `core-commands.sh` (shell-agnostic, ~38 assertions)
 
-Fish gets extra assertions covering the bugs uncovered during PR #434
-development: no fish parse errors in the templates, completions actually
-register after `pvm init fish | source`.
+Command-surface guarantees that don't depend on which shell invokes pvm.
+Covers `pvm version`, `pvm --help`, `pvm list`/`versions`, `pvm available`
+(offline), `pvm completion {bash,zsh,fish}`, `pvm config`, `pvm env list`,
+`pvm remote list`, `pvm detect-version`, `pvm self doctor`, `pvm current`
+/ `pvm current --bare`, plus `--help` for every top-level command to
+catch cobra registration bugs.
+
+## Per-shell journeys (~29–32 assertions each)
+
+`bash-journey.sh` / `zsh-journey.sh` / `fish-journey.fish` each source
+the real shell integration and exercise workflows that depend on the
+shell (env-var exports, PATH rewriting). Eight sections per shell:
+
+1. **Top-level command presence** — root `pvm --help` lists `local`,
+   `global`, `use [version[@library]]` (regression guard for #432).
+2. **Setup** — `pvm import-system` + fake version bin via
+   `smoke_setup_stub_perl`.
+3. **`pvm use`** — PATH rewrite, `PVM_PERL_VERSION` export, `perl -v`
+   reflects the switch, bogus version exits non-zero AND short-circuits
+   `&&` / `; and` chains (regression guard for #433).
+4. **`pvm local`** — writes `.perl-version`, `detect-version` sees it,
+   `--unset` removes it.
+5. **`pvm global`** — writes global config, `pvm current --bare` picks
+   it up, `--unset` clears it.
+6. **`pvm use system`** — clears `PVM_PERL_VERSION`.
+7. **Library environments** — `pvm env list` shows a manually-created
+   env, `pvm use X@testlib` exports `PVM_PERL_LIBRARY`, library bin
+   lands on PATH, library `lib/perl5` lands on `PERL5LIB`, clearing
+   via `pvm use X` unexports the library, `pvm env remove` tears it
+   down.
+8. **Doctor sanity** — `pvm self doctor` exits 0 on a clean container
+   and does NOT falsely flag stale installs (regression guard for
+   PR #436's disambiguation logic).
+
+Fish additionally asserts: no `Unknown command` errors from the template
+(PR #434 fish-template regressions), and completions actually register.
+
+## Total coverage
+
+~128 assertions across the four suites, covering roughly 20 of the 31
+top-level pvm commands. The six commands that require real Perl install
+(`install`, `build-perl`, `install-perl`, `module`, `run`/pvx, `psc`)
+intentionally stay out of smoke scope — they belong in the Go e2e suite
+(`test/docker/shell-integration/`) or a separate slow-tier CI job.
 
 ## Running
 

--- a/test/docker/smoke-test/journeys/advanced-commands.sh
+++ b/test/docker/smoke-test/journeys/advanced-commands.sh
@@ -132,10 +132,11 @@ pvm config set pvm.build_jobs 8 >/dev/null 2>&1
 smoke_exit_eq "$?" "0" "config set exits 0"
 
 got=$(pvm config get pvm.build_jobs 2>&1)
-case "$got" in
-    *8*) smoke_pass "config get round-trips pvm.build_jobs=8" ;;
-    *)   smoke_fail "config get returned [$got], expected to contain 8" ;;
-esac
+# `pvm config get` prints the raw value with a trailing newline. Trim and
+# assert equality — the previous *8* glob matched any output with an 8
+# anywhere (e.g., 128, paths, error keys) which defeated the round-trip.
+smoke_equals "$(echo "$got" | tr -d '[:space:]')" "8" \
+             "config get round-trips pvm.build_jobs=8"
 
 smoke_contains "$(pvm config sources 2>&1)" "Configuration Sources" \
                "config sources reports source-list header"

--- a/test/docker/smoke-test/journeys/advanced-commands.sh
+++ b/test/docker/smoke-test/journeys/advanced-commands.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# ABOUTME: Shell-agnostic advanced-workflow smoke suite. Covers the Jobs To
+# ABOUTME: Be Done that working Perl devs hit regularly but that core-commands
+#          doesn't: resolution-source attribution, JSON stability, workspace
+#          scaffolding, config round-trip, remote write-path, symlink verify.
+
+set -u
+source "$(dirname "$0")/common.sh"
+
+echo "=== advanced commands smoke test (shell-agnostic) ==="
+
+# Ensure we have a version to resolve against. This is redundant with
+# core-commands.sh's import-system but the journey should be standalone-
+# runnable; both are idempotent.
+pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
+VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+[ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
+
+############################################################################
+# Section 1 — G1: `pvm current` resolution attribution
+############################################################################
+
+# Clean slate: no .perl-version, no PVM_PERL_VERSION.
+cd "$HOME"
+rm -f .perl-version
+unset PVM_PERL_VERSION
+
+# Pin via .perl-version and assert --detailed names the file as source.
+echo "$VERSION" > "$HOME/.perl-version"
+det=$(pvm current --detailed 2>&1)
+smoke_contains "$det" ".perl-version" "current --detailed names the resolution source"
+smoke_contains "$det" "project_file" "current --detailed reports project_file resolution_method"
+
+# --json must be parseable and carry stable keys.
+json=$(pvm current --json 2>&1)
+for key in version source path available; do
+    case "$json" in
+        *"\"$key\""*) smoke_pass "current --json has key [$key]" ;;
+        *) smoke_fail "current --json missing key [$key]: $json" ;;
+    esac
+done
+# Try parsing JSON if python3 is available in the container.
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c "import json,sys; json.loads(sys.stdin.read())" <<< "$json" >/dev/null 2>&1; then
+        smoke_pass "current --json is well-formed JSON"
+    else
+        smoke_fail "current --json is not valid JSON: $json"
+    fi
+fi
+
+# G8: PVM_PERL_VERSION overrides .perl-version.
+export PVM_PERL_VERSION="$VERSION"
+env_src=$(pvm current --detailed 2>&1)
+# Source should no longer be project_file; should name env var or environment.
+case "$env_src" in
+    *environment*|*env_var*|*PVM_PERL_VERSION*)
+        smoke_pass "PVM_PERL_VERSION takes precedence over .perl-version" ;;
+    *)
+        smoke_fail "PVM_PERL_VERSION did not override .perl-version: $env_src" ;;
+esac
+unset PVM_PERL_VERSION
+rm -f "$HOME/.perl-version"
+
+############################################################################
+# Section 2 — G10: broken .perl-version degrades gracefully (no crash)
+############################################################################
+
+echo "9.9.9-does-not-exist" > "$HOME/.perl-version"
+broken_out=$(pvm current 2>&1)
+broken_rc=$?
+# pvm's current behavior: fall back to system Perl silently rather than
+# erroring. Either response is acceptable; a crash or unlimited hang is
+# not. Assert exit code is 0 or 1 (not 130, 137, etc.) and output is
+# non-empty.
+if [ "$broken_rc" -gt 1 ]; then
+    smoke_fail "pvm current crashed (exit=$broken_rc) on broken pin: $broken_out"
+fi
+[ -n "$broken_out" ] || smoke_fail "pvm current produced no output on broken pin"
+smoke_pass "pvm current handles broken .perl-version without crashing (exit=$broken_rc)"
+rm -f "$HOME/.perl-version"
+
+############################################################################
+# Section 3 — G3: workspace init scaffold
+############################################################################
+
+ws_root=$(mktemp -d)
+cd "$ws_root"
+init_out=$(pvm workspace init my-app 2>&1)
+smoke_contains "$init_out" "initialized successfully" "workspace init reports success"
+
+for f in .perl-version cpanfile pvm.toml .gitignore; do
+    [ -f "my-app/$f" ] || smoke_fail "workspace init did not create $f"
+done
+smoke_pass "workspace init creates .perl-version + cpanfile + pvm.toml + .gitignore"
+
+for d in lib t; do
+    [ -d "my-app/$d" ] || smoke_fail "workspace init did not create $d/"
+done
+smoke_pass "workspace init creates lib/ and t/"
+
+# .perl-version should carry a 5.x version string.
+content=$(cat my-app/.perl-version)
+case "$content" in
+    5.*) smoke_pass "workspace init .perl-version pins a 5.x version" ;;
+    *)   smoke_fail "workspace init .perl-version has unexpected content: $content" ;;
+esac
+
+# workspace status inside the project should NOT say "No workspace detected".
+cd my-app
+stat_out=$(pvm workspace status 2>&1)
+case "$stat_out" in
+    *"No workspace detected"*)
+        smoke_fail "workspace status inside project said 'No workspace detected'" ;;
+    *)
+        smoke_pass "workspace status recognizes the initialized project" ;;
+esac
+
+# workspace templates lists at least the built-in 'minimal' template.
+tmpl_out=$(pvm workspace templates 2>&1)
+smoke_contains "$tmpl_out" "minimal" "workspace templates lists 'minimal'"
+
+cd "$HOME"
+rm -rf "$ws_root"
+
+############################################################################
+# Section 4 — G5: config round-trip
+############################################################################
+
+# Use a key that's genuinely settable. pvm.build_jobs is a documented
+# user-facing knob; the value is an integer.
+pvm config set pvm.build_jobs 8 >/dev/null 2>&1
+smoke_exit_eq "$?" "0" "config set exits 0"
+
+got=$(pvm config get pvm.build_jobs 2>&1)
+case "$got" in
+    *8*) smoke_pass "config get round-trips pvm.build_jobs=8" ;;
+    *)   smoke_fail "config get returned [$got], expected to contain 8" ;;
+esac
+
+smoke_contains "$(pvm config sources 2>&1)" "Configuration Sources" \
+               "config sources reports source-list header"
+
+pvm config validate >/dev/null 2>&1
+smoke_exit_eq "$?" "0" "config validate exits 0"
+
+pvm config unset pvm.build_jobs >/dev/null 2>&1
+smoke_exit_eq "$?" "0" "config unset exits 0"
+
+############################################################################
+# Section 5 — G6: remote add + remove write-path
+############################################################################
+
+pvm remote add smoketest-remote https://example.com/perl.git >/dev/null 2>&1
+smoke_exit_eq "$?" "0" "remote add exits 0 for valid args"
+
+smoke_contains "$(pvm remote list 2>&1)" "smoketest-remote" \
+               "remote list shows the newly-added remote"
+
+pvm remote remove smoketest-remote >/dev/null 2>&1
+smoke_exit_eq "$?" "0" "remote remove exits 0"
+
+# After removal it should no longer appear.
+case "$(pvm remote list 2>&1)" in
+    *smoketest-remote*)
+        smoke_fail "remote remove did not delete smoketest-remote" ;;
+    *)
+        smoke_pass "remote remove actually deletes the entry" ;;
+esac
+
+# The built-in 'origin' remote must survive.
+smoke_contains "$(pvm remote list 2>&1)" "origin" \
+               "remote list still shows built-in origin after round-trip"
+
+############################################################################
+# Section 6 — G7: self symlinks verify
+############################################################################
+
+# verify exits 0 on a fresh container (the symlinks may or may not exist
+# depending on how pvm was installed — we're mainly asserting the command
+# doesn't crash and produces a parseable status report).
+sym_out=$(pvm self symlinks verify 2>&1)
+sym_rc=$?
+if [ "$sym_rc" -gt 1 ]; then
+    smoke_fail "pvm self symlinks verify crashed (exit=$sym_rc): $sym_out"
+fi
+smoke_contains "$sym_out" "pvm" "self symlinks verify mentions the pvm entry point"
+smoke_pass "self symlinks verify completes without crashing (exit=$sym_rc)"
+
+############################################################################
+# Section 7 — G9: rehash --dry-run does not mutate
+############################################################################
+
+# --dry-run should print what would happen, not actually rewrite PATH.
+# Capture PATH before and after and assert they're identical.
+path_before="$PATH"
+dry_out=$(pvm rehash --dry-run 2>&1)
+smoke_exit_eq "$?" "0" "rehash --dry-run exits 0"
+smoke_equals "$PATH" "$path_before" "rehash --dry-run does not mutate PATH"
+
+echo ""
+echo "=== advanced commands smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/advanced-commands.sh
+++ b/test/docker/smoke-test/journeys/advanced-commands.sh
@@ -13,7 +13,7 @@ echo "=== advanced commands smoke test (shell-agnostic) ==="
 # core-commands.sh's import-system but the journey should be standalone-
 # runnable; both are idempotent.
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
-VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+VERSION=$(smoke_first_installed_version)
 [ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
 
 ############################################################################

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -91,11 +91,19 @@ fi
 # UNSET it locally for the install and leave it set for the rest of
 # the suite. Skip gracefully if the network is unavailable.
 SECOND_VERSION="5.40.2"
-(
-    unset PVM_SKIP_NETWORK_CALLS
-    pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
-)
-install_rc=$?
+# CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
+# path until the release workflow ships signed SHA256 checksums. The
+# single-version fallback below still exercises the cd hook + PATH refresh.
+if [ "${PVM_SMOKE_SKIP_BINARY_INSTALL-}" = "1" ]; then
+    install_rc=1
+    smoke_pass "binary-install gated off (PVM_SMOKE_SKIP_BINARY_INSTALL=1)"
+else
+    (
+        unset PVM_SKIP_NETWORK_CALLS
+        pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
+    )
+    install_rc=$?
+fi
 if [ "$install_rc" -ne 0 ]; then
     # Likely offline; downgrade to the single-version G2 test (pinning
     # proves the hook fires, we just can't prove inter-version switch).

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -1,24 +1,28 @@
 #!/usr/bin/env bash
 # ABOUTME: Bash user journey smoke test. Runs inside the smoke-test container.
-# ABOUTME: Exercises the two user-reported bug scenarios (#432 local/global,
-#          #433 pvm use PATH refresh) plus the full activation flow.
+# ABOUTME: Exercises the user-facing workflows a bash user would rely on:
+#          local/global/use, env activation, library scoping, and the
+#          originally-reported bug scenarios (#432/#433) as regression guards.
 
 set -u
 source "$(dirname "$0")/common.sh"
 
 echo "=== bash smoke test ==="
 
-# --- issue #432: pvm local must exist at top level --------------------------
-local_help=$(pvm local --help 2>&1)
-smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+############################################################################
+# Section 1 — top-level command presence (#432 regression)
+############################################################################
 
-global_help=$(pvm global --help 2>&1)
-smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+# Root --help must list all three commands with their usage strings.
+root_help=$(pvm --help 2>&1)
+smoke_contains "$root_help" "local [version]"  "pvm local is a top-level command"
+smoke_contains "$root_help" "global [version]" "pvm global is a top-level command"
+smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 
-use_help=$(pvm --help 2>&1)
-smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+############################################################################
+# Section 2 — setup: import system perl, create a stub bin
+############################################################################
 
-# --- prerequisite: import system perl, fake a version dir -------------------
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 
 VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
@@ -26,34 +30,163 @@ VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
 
 smoke_setup_stub_perl "$VERSION"
 
-# --- issue #433 core: source integration, pvm use, PATH changes -------------
+############################################################################
+# Section 3 — pvm use: shell activation (#433 regression)
+############################################################################
+
 # shellcheck disable=SC1090
 source <(pvm init bash)
 
-pvm use "$VERSION" 2>&1 | grep -q "Using Perl $VERSION" \
-    || smoke_fail "pvm use did not print 'Using Perl $VERSION'"
-smoke_pass "pvm use prints Using Perl"
+# `pvm use` and `pvm env activate` modify the current shell's environment.
+# Piping to grep or $(…) would run them in a subshell and the env-var
+# exports would be lost. This helper captures output via a tempfile so the
+# parent shell's env changes survive.
+pvm_use_log=""
+pvm_use_run() {
+    pvm_use_log=$(mktemp)
+    # Deliberately no pipe / no $(…) — caller just uses this helper and
+    # then reads pvm_use_log to inspect output.
+    pvm "$@" > "$pvm_use_log" 2>&1
+}
 
-smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+pvm_use_run use "$VERSION"
+smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION" "pvm use prints Using Perl"
+rm -f "$pvm_use_log"
 
-front=$(echo "$PATH" | cut -d: -f1)
-smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
-    "version bin at front of PATH after pvm use"
+smoke_equals "${PVM_PERL_VERSION-}" "$VERSION" "PVM_PERL_VERSION exported"
 
-perl_out=$(perl -v 2>&1 | head -1)
-smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+             "version bin at front of PATH after pvm use"
 
-# --- issue #433 I1: bogus version must exit non-zero ------------------------
+smoke_contains "$(perl -v 2>&1 | head -1)" "v$VERSION" \
+               "perl -v reflects pvm use version"
+
+# Bogus version: non-zero exit + short-circuits &&. The full-loop regression
+# guard for #433 I1 (exit-code propagation through the shell function).
 pvm use not-a-real-version >/dev/null 2>&1
-rc=$?
-smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+smoke_exit_eq "$?" "1" "pvm use <bogus> returns non-zero exit"
 
-# --- shell integration contract: 'pvm use' is usable via 'A && B' -----------
 if pvm use not-a-real-version 2>/dev/null; then
     smoke_fail "pvm use <bogus> followed by && should NOT run the next command"
 else
     smoke_pass "pvm use <bogus> short-circuits && chains"
 fi
+
+############################################################################
+# Section 4 — pvm local: project-scoped pinning
+############################################################################
+
+# Reset the shell's env var so the .perl-version file is what resolves.
+pvm use "$VERSION" >/dev/null 2>&1
+
+cd "$HOME"
+pvm local "$VERSION" 2>&1 | grep -q "Local Perl version set" \
+    || smoke_fail "pvm local did not confirm write"
+smoke_pass "pvm local confirms write"
+[ -f "$HOME/.perl-version" ] || smoke_fail "pvm local did not create .perl-version"
+smoke_equals "$(cat "$HOME/.perl-version")" "$VERSION" "pvm local wrote $VERSION"
+
+# detect-version finds it.
+smoke_contains "$(pvm detect-version 2>&1)" ".perl-version" \
+               "pvm detect-version sees the pin"
+
+pvm local --unset 2>&1 | grep -q "unset" \
+    || smoke_fail "pvm local --unset did not confirm"
+[ ! -f "$HOME/.perl-version" ] || smoke_fail "pvm local --unset did not remove the file"
+smoke_pass "pvm local --unset removes .perl-version"
+
+############################################################################
+# Section 5 — pvm global: user-scoped default
+############################################################################
+
+# Clear any shell-level override so global is actually consulted.
+unset PVM_PERL_VERSION
+
+pvm global "$VERSION" 2>&1 | grep -q "Global Perl version set" \
+    || smoke_fail "pvm global did not confirm"
+smoke_pass "pvm global confirms write"
+smoke_contains "$(pvm current --bare 2>&1)" "$VERSION" \
+               "pvm current --bare reads pvm global"
+
+pvm global --unset 2>&1 | grep -q "unset" \
+    || smoke_fail "pvm global --unset did not confirm"
+smoke_pass "pvm global --unset clears default"
+
+############################################################################
+# Section 6 — pvm use system: clears the env-var override
+############################################################################
+
+pvm use "$VERSION" >/dev/null 2>&1
+smoke_equals "$PVM_PERL_VERSION" "$VERSION" "sanity: version active before use system"
+
+pvm_use_run use system
+smoke_contains "$(cat "$pvm_use_log")" "Using system Perl" \
+               "pvm use system prints 'Using system Perl'"
+rm -f "$pvm_use_log"
+[ -z "${PVM_PERL_VERSION-}" ] || smoke_fail "pvm use system did not clear PVM_PERL_VERSION"
+smoke_pass "pvm use system clears PVM_PERL_VERSION"
+
+############################################################################
+# Section 7 — library environments (@library syntax + env lifecycle)
+############################################################################
+
+# Create a fake library env on disk so pvm env list/activate can see it.
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/bin"
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5"
+
+smoke_contains "$(pvm env list 2>&1)" "testlib" "pvm env list shows testlib"
+
+# pvm use X@library sets PVM_PERL_LIBRARY; shell integration must honor it.
+pvm_use_run use "$VERSION@testlib"
+smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION@testlib" \
+               "pvm use X@lib prints 'Using Perl X@lib'"
+rm -f "$pvm_use_log"
+smoke_equals "${PVM_PERL_LIBRARY-}" "testlib" "PVM_PERL_LIBRARY exported by sh-use"
+
+# _pvm_update_perl_path should now have library bin + perl5 on PATH/PERL5LIB.
+# (This is PR #434's I5 fix; bash already had the handling, but this locks
+# it in as a user-visible journey rather than template text.)
+case ":$PATH:" in
+    *":$XDG_DATA_HOME/pvm/environments/testlib/bin:"*)
+        smoke_pass "library bin is on PATH after pvm use X@library" ;;
+    *)
+        smoke_fail "library bin NOT on PATH after pvm use X@library; PATH=$PATH" ;;
+esac
+
+case ":${PERL5LIB:-}:" in
+    *":$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5:"*)
+        smoke_pass "library lib/perl5 is on PERL5LIB after pvm use X@library" ;;
+    *)
+        smoke_fail "library lib/perl5 NOT on PERL5LIB; PERL5LIB=${PERL5LIB:-<unset>}" ;;
+esac
+
+# Clear the library by switching to a version without @library.
+pvm use "$VERSION" >/dev/null 2>&1
+[ -z "${PVM_PERL_LIBRARY:-}" ] || smoke_fail "pvm use X (no @) did not clear PVM_PERL_LIBRARY"
+smoke_pass "pvm use X (no @) clears PVM_PERL_LIBRARY"
+
+# pvm env remove is interactive ([y/N]). Pipe 'y' to confirm.
+rm_out=$(echo y | pvm env remove testlib 2>&1)
+smoke_contains "$rm_out" "has been removed" "pvm env remove confirms removal"
+[ ! -d "$XDG_DATA_HOME/pvm/environments/testlib" ] \
+    || smoke_fail "pvm env remove did not delete the directory"
+smoke_pass "pvm env remove tears the env down"
+
+############################################################################
+# Section 8 — doctor sanity in this fully-configured shell
+############################################################################
+
+# After all the setup above, self doctor should still report a healthy
+# install (exit 0) and NOT falsely flag the running binary as stale.
+doctor_out=$(pvm self doctor 2>&1)
+smoke_exit_eq "$?" "0" "pvm self doctor exits 0 in bash journey"
+# The stale-install warning (PR #436) must not fire here — container has
+# exactly one pvm binary at /usr/local/bin/pvm.
+if echo "$doctor_out" | grep -q "Multiple pvm binaries in PATH"; then
+    smoke_fail "self doctor incorrectly flagged stale installs in clean container"
+fi
+smoke_pass "self doctor: no false stale-install warning"
 
 echo ""
 echo "=== bash smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -185,7 +185,7 @@ smoke_pass "pvm global --unset clears default"
 ############################################################################
 
 pvm use "$VERSION" >/dev/null 2>&1
-smoke_equals "$PVM_PERL_VERSION" "$VERSION" "sanity: version active before use system"
+smoke_equals "${PVM_PERL_VERSION-}" "$VERSION" "sanity: version active before use system"
 
 pvm_use_run use system
 smoke_contains "$(cat "$pvm_use_log")" "Using system Perl" \

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -78,32 +78,67 @@ else
 fi
 
 ############################################################################
-# Section 3b — G2: cd auto-switch hook recognizes .perl-version
+# Section 3b — G2: cd auto-switch between TWO installed versions
 ############################################################################
 
-# Clear the env-var override so .perl-version is what resolves on cd.
-unset PVM_PERL_VERSION
+# Install a second Perl via pvm's binary-fetch path so the registry
+# knows two distinct versions, then cd between project dirs pinning
+# each. This exercises the real JTBD: dev switches projects, shell
+# auto-activates the right interpreter, no manual pvm use needed.
+#
+# This section needs network (to fetch the binary). The container
+# sets PVM_SKIP_NETWORK_CALLS=1 as a default for determinism; only
+# UNSET it locally for the install and leave it set for the rest of
+# the suite. Skip gracefully if the network is unavailable.
+SECOND_VERSION="5.40.2"
+(
+    unset PVM_SKIP_NETWORK_CALLS
+    pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
+)
+install_rc=$?
+if [ "$install_rc" -ne 0 ]; then
+    # Likely offline; downgrade to the single-version G2 test (pinning
+    # proves the hook fires, we just can't prove inter-version switch).
+    smoke_pass "skipping two-version auto-switch (install rc=$install_rc; network?)"
+    unset PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a"
+    echo "$VERSION" > "$HOME/proj-a/.perl-version"
+    cd "$HOME/proj-a"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+                 "cd fires hook (single-version fallback): resolves pinned version"
+    cd "$HOME"
+else
+    smoke_pass "pvm install --binary-only fetched $SECOND_VERSION"
 
-# Project A pins the installed version. After cd, the hook runs
-# _pvm_update_perl_path, which queries `pvm current --bare` and should
-# resolve to the pinned version (via the walk-up .perl-version resolver),
-# putting its bin at the front of PATH.
-mkdir -p "$HOME/proj-a"
-echo "$VERSION" > "$HOME/proj-a/.perl-version"
-cd "$HOME/proj-a"
-smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
-             "cd into project resolves via .perl-version"
-smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
-             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
-             "cd fires hook — PATH front is pinned version's bin"
+    # Now exercise the auto-switch between two distinct REAL versions.
+    unset PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a" "$HOME/proj-b"
+    echo "$VERSION"        > "$HOME/proj-a/.perl-version"
+    echo "$SECOND_VERSION" > "$HOME/proj-b/.perl-version"
 
-# cd out to a directory without .perl-version. Hook should still fire
-# (and either keep the version or fall back to system — but crucially
-# must NOT crash the shell).
-cd "$HOME"
-# No assertion on PATH here; resolver may fall back to various defaults.
-# The point is that cd didn't error out.
-smoke_pass "cd out of project directory completes cleanly"
+    cd "$HOME/proj-a"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+                 "cd into proj-a: auto-switch resolves to $VERSION"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+                 "cd into proj-a: PATH front matches $VERSION's bin"
+
+    cd "$HOME/proj-b"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$SECOND_VERSION" \
+                 "cd into proj-b: auto-switch resolves to $SECOND_VERSION"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$SECOND_VERSION/bin" \
+                 "cd into proj-b: PATH front matches $SECOND_VERSION's bin"
+
+    # cd back to the first project; PATH must swing back.
+    cd "$HOME/proj-a"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+                 "cd back to proj-a: PATH front swings back to $VERSION's bin"
+
+    cd "$HOME"
+fi
+rm -f /tmp/install.log
 
 ############################################################################
 # Section 4 — pvm local: project-scoped pinning

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -29,7 +29,7 @@ smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 
-VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+VERSION=$(smoke_first_installed_version)
 [ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
 
 smoke_setup_stub_perl "$VERSION"
@@ -41,18 +41,9 @@ smoke_setup_stub_perl "$VERSION"
 # shellcheck disable=SC1090
 source <(pvm init bash)
 
-# `pvm use` and `pvm env activate` modify the current shell's environment.
-# Piping to grep or $(…) would run them in a subshell and the env-var
-# exports would be lost. This helper captures output via a tempfile so the
-# parent shell's env changes survive.
-pvm_use_log=""
-pvm_use_run() {
-    pvm_use_log=$(mktemp)
-    # Deliberately no pipe / no $(…) — caller just uses this helper and
-    # then reads pvm_use_log to inspect output.
-    pvm "$@" > "$pvm_use_log" 2>&1
-}
-
+# pvm_use_run + pvm_use_log live in common.sh — using a tempfile is the
+# only way to capture output while preserving the env exports pvm makes
+# in the parent shell.
 pvm_use_run use "$VERSION"
 smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION" "pvm use prints Using Perl"
 rm -f "$pvm_use_log"
@@ -90,7 +81,7 @@ fi
 # sets PVM_SKIP_NETWORK_CALLS=1 as a default for determinism; only
 # UNSET it locally for the install and leave it set for the rest of
 # the suite. Skip gracefully if the network is unavailable.
-SECOND_VERSION="5.40.2"
+SECOND_VERSION="$SMOKE_SECOND_VERSION"
 # CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
 # path until the release workflow ships signed SHA256 checksums. The
 # single-version fallback below still exercises the cd hook + PATH refresh.

--- a/test/docker/smoke-test/journeys/bash-journey.sh
+++ b/test/docker/smoke-test/journeys/bash-journey.sh
@@ -5,6 +5,10 @@
 #          originally-reported bug scenarios (#432/#433) as regression guards.
 
 set -u
+# Bash strips aliases from non-interactive scripts by default. The pvm init
+# template installs `alias cd="pvm_cd"` as its auto-switch hook; we need
+# expand_aliases ON so the G2 test below actually exercises that hook.
+shopt -s expand_aliases
 source "$(dirname "$0")/common.sh"
 
 echo "=== bash smoke test ==="
@@ -72,6 +76,34 @@ if pvm use not-a-real-version 2>/dev/null; then
 else
     smoke_pass "pvm use <bogus> short-circuits && chains"
 fi
+
+############################################################################
+# Section 3b — G2: cd auto-switch hook recognizes .perl-version
+############################################################################
+
+# Clear the env-var override so .perl-version is what resolves on cd.
+unset PVM_PERL_VERSION
+
+# Project A pins the installed version. After cd, the hook runs
+# _pvm_update_perl_path, which queries `pvm current --bare` and should
+# resolve to the pinned version (via the walk-up .perl-version resolver),
+# putting its bin at the front of PATH.
+mkdir -p "$HOME/proj-a"
+echo "$VERSION" > "$HOME/proj-a/.perl-version"
+cd "$HOME/proj-a"
+smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+             "cd into project resolves via .perl-version"
+smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+             "cd fires hook — PATH front is pinned version's bin"
+
+# cd out to a directory without .perl-version. Hook should still fire
+# (and either keep the version or fall back to system — but crucially
+# must NOT crash the shell).
+cd "$HOME"
+# No assertion on PATH here; resolver may fall back to various defaults.
+# The point is that cd didn't error out.
+smoke_pass "cd out of project directory completes cleanly"
 
 ############################################################################
 # Section 4 — pvm local: project-scoped pinning

--- a/test/docker/smoke-test/journeys/common.fish
+++ b/test/docker/smoke-test/journeys/common.fish
@@ -19,7 +19,11 @@ function smoke_contains
     if string match -q "*$expected*" -- $actual
         smoke_pass $label
     else
-        smoke_fail "$label: expected to contain [$expected], got [$actual]"
+        set -l truncated $actual
+        if test (string length -- "$actual") -gt 200
+            set truncated (string sub -l 200 -- "$actual")"… (truncated)"
+        end
+        smoke_fail "$label: expected to contain [$expected], got [$truncated]"
     end
 end
 

--- a/test/docker/smoke-test/journeys/common.fish
+++ b/test/docker/smoke-test/journeys/common.fish
@@ -51,6 +51,27 @@ function smoke_exit_eq
     end
 end
 
+# Second Perl version used by Section 3b (G2) for the two-version cd
+# auto-switch. Hoisted here so bumping the pinned binary-fetch target is
+# a one-line change. Accepts override from the environment.
+if not set -q SMOKE_SECOND_VERSION
+    set -gx SMOKE_SECOND_VERSION "5.40.2"
+end
+
+# Extract the first 5.x.y version pvm reports as installed.
+function smoke_first_installed_version
+    pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | head -1
+end
+
+# Run `pvm use ...` and capture output to a tempfile so env exports in the
+# parent shell survive. Callers read $pvm_use_log afterwards and rm -f it.
+# See common.sh's pvm_use_run for the rationale.
+set -g pvm_use_log ""
+function pvm_use_run
+    set -g pvm_use_log (mktemp)
+    pvm $argv > $pvm_use_log 2>&1
+end
+
 # Create a stub perl executable under $XDG_DATA_HOME/pvm/versions/$1/bin/perl
 # whose `perl -v` output matches the canonical real-perl shape. Emit three
 # integers for major/minor/patch so any future regex-based parser finds the

--- a/test/docker/smoke-test/journeys/common.sh
+++ b/test/docker/smoke-test/journeys/common.sh
@@ -53,6 +53,35 @@ smoke_exit_eq() {
     fi
 }
 
+# Second Perl version used by Section 3b (G2) to exercise the two-version
+# cd auto-switch. Hoisted here so bumping the pinned binary-fetch target
+# is a one-line change instead of editing every journey file.
+: "${SMOKE_SECOND_VERSION:=5.40.2}"
+export SMOKE_SECOND_VERSION
+
+# Extract the first 5.x.y version pvm reports as installed. Idempotent and
+# side-effect-free; used by every per-shell journey and by advanced-commands.
+smoke_first_installed_version() {
+    pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1
+}
+
+# Run `pvm use ...` (or any pvm subcommand that modifies the current shell
+# environment) and capture output to a tempfile so the parent shell keeps
+# its env-var exports. Callers read the tempfile path from $pvm_use_log.
+#
+# Why this exists: `pvm use X | grep ...` or `$(pvm use X)` run pvm in a
+# subshell, which means PVM_PERL_VERSION / PATH exports are discarded
+# before the caller can observe them. The tempfile pattern keeps the
+# export machinery in the parent shell.
+#
+# NB: pvm_use_log is intentionally a global — callers inspect it after
+# the helper returns. rm -f it once done.
+pvm_use_log=""
+pvm_use_run() {
+    pvm_use_log=$(mktemp)
+    pvm "$@" > "$pvm_use_log" 2>&1
+}
+
 # Create a stub perl executable under $XDG_DATA_HOME/pvm/versions/$1/bin/perl
 # whose `perl -v` output matches the canonical real-perl shape. Emit three
 # integers for major/minor/patch so any future regex-based parser finds the

--- a/test/docker/smoke-test/journeys/common.sh
+++ b/test/docker/smoke-test/journeys/common.sh
@@ -16,12 +16,20 @@ smoke_pass() {
 }
 
 # Assert a string contains a substring. First arg is the actual value, second
-# is the expected substring, third is a human-readable label.
+# is the expected substring, third is a human-readable label. Error messages
+# truncate long `actual` values to keep failure output readable (completion
+# scripts are hundreds of lines).
 smoke_contains() {
     local actual="$1" expected="$2" label="$3"
     case "$actual" in
         *"$expected"*) smoke_pass "$label" ;;
-        *) smoke_fail "$label: expected to contain [$expected], got [$actual]" ;;
+        *)
+            local truncated="$actual"
+            if [ "${#truncated}" -gt 200 ]; then
+                truncated="${truncated:0:200}… (truncated, ${#actual} chars total)"
+            fi
+            smoke_fail "$label: expected to contain [$expected], got [$truncated]"
+            ;;
     esac
 }
 

--- a/test/docker/smoke-test/journeys/core-commands.sh
+++ b/test/docker/smoke-test/journeys/core-commands.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# ABOUTME: Shell-agnostic smoke suite. Covers commands whose behavior does
+# ABOUTME: not depend on which shell invokes them, so we run them once (from
+#          bash) instead of three times across bash/zsh/fish.
+
+set -u
+source "$(dirname "$0")/common.sh"
+
+echo "=== core commands smoke test (shell-agnostic) ==="
+
+# --- identification --------------------------------------------------------
+
+smoke_contains "$(pvm version 2>&1)" "pvm " "pvm version prints version line"
+# Any top-level --help succeeds and mentions the command name.
+smoke_contains "$(pvm --help 2>&1)" "Perl Version Manager" "pvm --help shows description"
+
+# Every documented top-level command we advertise in gh-pages/reference/pvm.html
+# must exist and at least accept --help without error. Cheap sanity that the
+# root AddCommand block doesn't silently lose entries (issue #432 class).
+for cmd in install uninstall versions list use global local current available \
+           rehash import-system init completion self env remote config; do
+    out=$(pvm "$cmd" --help 2>&1)
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+        smoke_fail "pvm $cmd --help exited $rc (command missing or broken)"
+    fi
+    smoke_pass "pvm $cmd --help exits 0"
+done
+
+# --- version listing & registry --------------------------------------------
+
+pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed on fresh container"
+smoke_pass "import-system ingests container's system Perl"
+
+list_out=$(pvm list 2>&1)
+smoke_contains "$list_out" "Installed Perl versions" "pvm list has a header"
+smoke_contains "$list_out" "5." "pvm list shows at least one 5.x version"
+
+# versions is an alias for list per reference docs; both must work.
+versions_out=$(pvm versions 2>&1)
+smoke_contains "$versions_out" "5." "pvm versions (alias for list) shows the same"
+
+# `available` hits the network by default; with PVM_SKIP_NETWORK_CALLS=1 the
+# container forces it offline. The command should degrade gracefully rather
+# than spin for 10s or crash.
+avail_out=$(pvm available 2>&1)
+avail_rc=$?
+if [ "$avail_rc" -eq 0 ] || [ "$avail_rc" -eq 1 ]; then
+    smoke_pass "pvm available returns promptly offline (exit=$avail_rc)"
+else
+    smoke_fail "pvm available exited with unexpected code $avail_rc: $avail_out"
+fi
+
+# --- completion scripts ----------------------------------------------------
+
+for shell in bash zsh fish; do
+    comp_out=$(pvm completion "$shell" 2>&1)
+    # Shell-appropriate marker — bash/fish use `complete`, zsh uses #compdef.
+    case "$shell" in
+        bash) marker="_pvm_completion" ;;
+        zsh)  marker="#compdef" ;;
+        fish) marker="complete -c pvm" ;;
+    esac
+    if [ -z "$comp_out" ]; then
+        smoke_fail "pvm completion $shell emitted empty output"
+    fi
+    case "$comp_out" in
+        *"$marker"*) smoke_pass "pvm completion $shell emits completion rules" ;;
+        *) smoke_fail "pvm completion $shell missing marker [$marker]" ;;
+    esac
+done
+
+# --- config / env / remote: introspection-only commands --------------------
+
+# `config` should list keys without requiring any prior setup. The subcommand
+# may be called `list`, `show`, or `get` depending on version — we only assert
+# it exits 0 and prints *something*.
+cfg_out=$(pvm config 2>&1)
+cfg_rc=$?
+smoke_exit_eq "$cfg_rc" "0" "pvm config (no args) exits 0"
+[ -n "$cfg_out" ] || smoke_fail "pvm config produced no output"
+smoke_pass "pvm config produces output"
+
+env_out=$(pvm env list 2>&1)
+smoke_contains "$env_out" "environments" "pvm env list mentions environments"
+
+remote_out=$(pvm remote list 2>&1)
+# Fresh install has at least the built-in 'origin' remote.
+smoke_contains "$remote_out" "origin" "pvm remote list shows built-in origin"
+
+# --- directory-resolver sanity --------------------------------------------
+
+# detect-version walks up from PWD looking for .perl-version. In an empty dir
+# it should either print nothing or indicate no file found — exit 0 or 1 are
+# both acceptable; a crash is not.
+dv_out=$(pvm detect-version 2>&1)
+dv_rc=$?
+if [ "$dv_rc" -gt 1 ]; then
+    smoke_fail "pvm detect-version exited $dv_rc on empty dir: $dv_out"
+fi
+smoke_pass "pvm detect-version doesn't crash (exit=$dv_rc)"
+
+# --- diagnostic: self doctor -----------------------------------------------
+
+# doctor must exit 0 on the fresh container (warnings are acceptable; errors
+# would mean the install is broken before any user journey starts).
+doctor_out=$(pvm self doctor 2>&1)
+doctor_rc=$?
+smoke_exit_eq "$doctor_rc" "0" "pvm self doctor exits 0 on fresh container"
+smoke_contains "$doctor_out" "PVM Doctor" "pvm self doctor runs diagnostics"
+
+# --- current-version resolution --------------------------------------------
+
+# After import-system a version exists; `pvm current` must resolve it rather
+# than erroring.
+cur_out=$(pvm current 2>&1)
+cur_rc=$?
+smoke_exit_eq "$cur_rc" "0" "pvm current exits 0 post-import"
+smoke_contains "$cur_out" "5." "pvm current names a 5.x version"
+
+cur_bare=$(pvm current --bare 2>&1)
+smoke_contains "$cur_bare" "5." "pvm current --bare outputs just a version"
+# Bare output must be a single line.
+line_count=$(printf '%s\n' "$cur_bare" | wc -l)
+smoke_equals "$line_count" "1" "pvm current --bare outputs single line"
+
+echo ""
+echo "=== core commands smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -72,6 +72,23 @@ pvm use not-a-real-version 2>/dev/null
 and smoke_fail "pvm use <bogus> followed by `; and` should NOT run the next command"
 smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 
+############################################################################
+# Section 3b — G2: cd auto-switch hook (fish --on-variable PWD)
+############################################################################
+
+set -e PVM_PERL_VERSION
+
+mkdir -p "$HOME/proj-a"
+echo "$requested_version" > "$HOME/proj-a/.perl-version"
+cd "$HOME/proj-a"
+smoke_equals (pvm current --bare 2>/dev/null) "$requested_version" \
+    "cd into project resolves via .perl-version (--on-variable PWD hook)"
+set -l cd_front (string split : -- $PATH | head -1)
+smoke_equals "$cd_front" "$XDG_DATA_HOME/pvm/versions/$requested_version/bin" \
+    "cd fires PWD hook — PATH front is pinned version's bin"
+cd "$HOME"
+smoke_pass "cd out of project directory completes cleanly"
+
 # Completions must register (C2 regression from PR #434). Note: the init
 # template gates the auto-registration on PVM_SKIP_NETWORK_CALLS, which is
 # set to 1 in this container to suppress MetaCPAN calls. Source the

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -77,11 +77,20 @@ smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 ############################################################################
 
 set -l second_version "5.40.2"
-begin
-    set -e PVM_SKIP_NETWORK_CALLS
-    pvm install "$second_version" --binary-only >/tmp/install.log 2>&1
+# CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
+# path until the release workflow ships signed SHA256 checksums. The
+# single-version fallback below still exercises the PWD hook + PATH refresh.
+set -l install_rc
+if test "$PVM_SMOKE_SKIP_BINARY_INSTALL" = "1"
+    set install_rc 1
+    smoke_pass "binary-install gated off (PVM_SMOKE_SKIP_BINARY_INSTALL=1)"
+else
+    begin
+        set -e PVM_SKIP_NETWORK_CALLS
+        pvm install "$second_version" --binary-only >/tmp/install.log 2>&1
+    end
+    set install_rc $status
 end
-set -l install_rc $status
 if test $install_rc -ne 0
     smoke_pass "skipping two-version auto-switch (install rc=$install_rc; network?)"
     set -e PVM_PERL_VERSION

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -1,72 +1,197 @@
 #!/usr/bin/env fish
 # ABOUTME: Fish user journey smoke test. Runs inside the smoke-test container.
-# ABOUTME: Mirrors bash-journey.sh using fish idioms; especially valuable since
-#          fish uncovered multiple template bugs during PR #434 development.
+# ABOUTME: Mirrors bash-journey.sh using fish idioms. Especially valuable: fish
+#          uncovered multiple template bugs during PR #434 and was the shell
+#          that motivated the smoke-test container in the first place.
 
 source (dirname (status -f))/common.fish
 
 echo "=== fish smoke test ==="
 
-# Top-level commands exist
-set -l local_help (pvm local --help 2>&1 | string collect)
-smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+############################################################################
+# Section 1 — top-level command presence (#432 regression)
+############################################################################
 
-set -l global_help (pvm global --help 2>&1 | string collect)
-smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+set -l root_help (pvm --help 2>&1 | string collect)
+smoke_contains "$root_help" "local [version]"  "pvm local is a top-level command"
+smoke_contains "$root_help" "global [version]" "pvm global is a top-level command"
+smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 
-set -l use_help (pvm --help 2>&1 | string collect)
-smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+############################################################################
+# Section 2 — setup
+############################################################################
 
-# Import system perl + fake version dir
 pvm import-system >/dev/null 2>&1
 or smoke_fail "import-system failed"
 
-set -l VERSION (pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | head -1)
-test -n "$VERSION"
+set -l requested_version (pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | head -1)
+test -n "$requested_version"
 or smoke_fail "no Perl version found after import-system"
 
-smoke_setup_stub_perl "$VERSION"
+smoke_setup_stub_perl "$requested_version"
 
-# Source pvm init — must not error
+############################################################################
+# Section 3 — pvm use: shell activation (#433 regression)
+############################################################################
+
 pvm init fish | source
 or smoke_fail "sourcing pvm init fish failed"
 smoke_pass "sourced pvm init fish cleanly"
 
-# Run pvm use; capture output AND stderr to catch template errors
-set -l use_out (pvm use "$VERSION" 2>&1 | string collect)
-smoke_contains "$use_out" "Using Perl $VERSION" "pvm use prints Using Perl"
-# No stray 'Unknown command: unset' or similar fish-parse errors
+# `pvm use` / `pvm env activate` modify the shell's env. Running them under
+# `(…)` command substitution puts them in a subshell and the exports are
+# lost. Use a tempfile to inspect output while keeping the env changes.
+set -g pvm_use_log ""
+function pvm_use_run
+    set -g pvm_use_log (mktemp)
+    pvm $argv > $pvm_use_log 2>&1
+end
+
+pvm_use_run use "$requested_version"
+set -l use_out (cat $pvm_use_log | string collect)
+smoke_contains "$use_out" "Using Perl $requested_version" "pvm use prints Using Perl"
 if string match -q "*Unknown command*" -- $use_out
     smoke_fail "pvm use produced a fish parse error: $use_out"
 end
 smoke_pass "pvm use output is fish-clean (no Unknown command errors)"
+rm -f $pvm_use_log
 
-smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+smoke_equals "$PVM_PERL_VERSION" "$requested_version" "PVM_PERL_VERSION exported"
 
 set -l front (string split : -- $PATH | head -1)
-smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$requested_version/bin" \
     "version bin at front of PATH after pvm use"
 
 set -l perl_out (perl -v 2>&1 | head -1 | string collect)
-smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+smoke_contains "$perl_out" "v$requested_version" "perl -v reflects pvm use version"
 
-# Bogus version must exit non-zero (tests $pipestatus[1] plumbing)
 pvm use not-a-real-version >/dev/null 2>&1
-set -l rc $status
-smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+smoke_exit_eq "$status" "1" "pvm use <bogus> returns non-zero exit"
 
-# Shell-level contract: `pvm use <bogus>; and ...` must short-circuit
-# (fish uses `; and` where POSIX uses `&&`).
 pvm use not-a-real-version 2>/dev/null
 and smoke_fail "pvm use <bogus> followed by `; and` should NOT run the next command"
 smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 
-# Completion must actually register (C2 regression)
+# Completions must register (C2 regression from PR #434). Note: the init
+# template gates the auto-registration on PVM_SKIP_NETWORK_CALLS, which is
+# set to 1 in this container to suppress MetaCPAN calls. Source the
+# completion output manually here — it's the same code path that runs at
+# interactive startup, minus the gate.
+pvm completion fish 2>/dev/null | source
 set -l pvm_completions (complete -c pvm 2>/dev/null | count)
 if test $pvm_completions -lt 5
     smoke_fail "fish completions did not register (found $pvm_completions rules)"
 end
 smoke_pass "fish completions registered ($pvm_completions rules)"
+
+############################################################################
+# Section 4 — pvm local
+############################################################################
+
+pvm use "$requested_version" >/dev/null 2>&1
+cd "$HOME"
+
+pvm local "$requested_version" 2>&1 | grep -q "Local Perl version set"
+or smoke_fail "pvm local did not confirm"
+smoke_pass "pvm local confirms write"
+test -f "$HOME/.perl-version"
+or smoke_fail "pvm local did not create .perl-version"
+smoke_equals (cat "$HOME/.perl-version") "$requested_version" "pvm local wrote $requested_version"
+
+smoke_contains (pvm detect-version 2>&1 | string collect) ".perl-version" \
+    "pvm detect-version sees the pin"
+
+pvm local --unset 2>&1 | grep -q "unset"
+or smoke_fail "pvm local --unset failed"
+test ! -f "$HOME/.perl-version"
+or smoke_fail "pvm local --unset did not remove file"
+smoke_pass "pvm local --unset removes .perl-version"
+
+############################################################################
+# Section 5 — pvm global
+############################################################################
+
+set -e PVM_PERL_VERSION
+
+pvm global "$requested_version" 2>&1 | grep -q "Global Perl version set"
+or smoke_fail "pvm global did not confirm"
+smoke_pass "pvm global confirms write"
+smoke_contains (pvm current --bare 2>&1 | string collect) "$requested_version" \
+    "pvm current --bare reads pvm global"
+
+pvm global --unset 2>&1 | grep -q "unset"
+or smoke_fail "pvm global --unset failed"
+smoke_pass "pvm global --unset clears default"
+
+############################################################################
+# Section 6 — pvm use system
+############################################################################
+
+pvm use "$requested_version" >/dev/null 2>&1
+smoke_equals "$PVM_PERL_VERSION" "$requested_version" "sanity: version active before use system"
+
+pvm_use_run use system
+smoke_contains (cat $pvm_use_log | string collect) "Using system Perl" \
+    "pvm use system prints 'Using system Perl'"
+rm -f $pvm_use_log
+if set -q PVM_PERL_VERSION
+    smoke_fail "pvm use system did not clear PVM_PERL_VERSION"
+end
+smoke_pass "pvm use system clears PVM_PERL_VERSION"
+
+############################################################################
+# Section 7 — library environments (main fix target of PR #434 I5 for fish)
+############################################################################
+
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/bin"
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5"
+
+smoke_contains (pvm env list 2>&1 | string collect) "testlib" "pvm env list shows testlib"
+
+pvm_use_run use "$requested_version@testlib"
+smoke_contains (cat $pvm_use_log | string collect) "Using Perl $requested_version@testlib" \
+    "pvm use X@lib prints 'Using Perl X@lib'"
+rm -f $pvm_use_log
+smoke_equals "$PVM_PERL_LIBRARY" "testlib" "PVM_PERL_LIBRARY exported"
+
+if contains "$XDG_DATA_HOME/pvm/environments/testlib/bin" $PATH
+    smoke_pass "library bin is on PATH after pvm use X@library"
+else
+    smoke_fail "library bin NOT on PATH after pvm use X@library; PATH=$PATH"
+end
+
+set -l perl5lib_parts
+if set -q PERL5LIB
+    set perl5lib_parts (string split : -- $PERL5LIB)
+end
+if contains "$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5" $perl5lib_parts
+    smoke_pass "library lib/perl5 is on PERL5LIB after pvm use X@library"
+else
+    smoke_fail "library lib/perl5 NOT on PERL5LIB; PERL5LIB="(set -q PERL5LIB; and echo $PERL5LIB; or echo '<unset>')
+end
+
+pvm use "$requested_version" >/dev/null 2>&1
+if set -q PVM_PERL_LIBRARY
+    smoke_fail "pvm use X (no @) did not clear PVM_PERL_LIBRARY"
+end
+smoke_pass "pvm use X (no @) clears PVM_PERL_LIBRARY"
+
+set -l rm_out (echo y | pvm env remove testlib 2>&1 | string collect)
+smoke_contains "$rm_out" "has been removed" "pvm env remove confirms removal"
+test ! -d "$XDG_DATA_HOME/pvm/environments/testlib"
+or smoke_fail "pvm env remove did not delete the directory"
+smoke_pass "pvm env remove tears the env down"
+
+############################################################################
+# Section 8 — doctor sanity
+############################################################################
+
+set -l doctor_out (pvm self doctor 2>&1 | string collect)
+smoke_exit_eq "$status" "0" "pvm self doctor exits 0 in fish journey"
+if string match -q "*Multiple pvm binaries in PATH*" -- $doctor_out
+    smoke_fail "self doctor incorrectly flagged stale installs in clean container"
+end
+smoke_pass "self doctor: no false stale-install warning"
 
 echo ""
 echo "=== fish smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -73,21 +73,54 @@ and smoke_fail "pvm use <bogus> followed by `; and` should NOT run the next comm
 smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 
 ############################################################################
-# Section 3b — G2: cd auto-switch hook (fish --on-variable PWD)
+# Section 3b — G2: cd auto-switch between TWO installed versions
 ############################################################################
 
-set -e PVM_PERL_VERSION
+set -l second_version "5.40.2"
+begin
+    set -e PVM_SKIP_NETWORK_CALLS
+    pvm install "$second_version" --binary-only >/tmp/install.log 2>&1
+end
+set -l install_rc $status
+if test $install_rc -ne 0
+    smoke_pass "skipping two-version auto-switch (install rc=$install_rc; network?)"
+    set -e PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a"
+    echo "$requested_version" > "$HOME/proj-a/.perl-version"
+    cd "$HOME/proj-a"
+    smoke_equals (pvm current --bare 2>/dev/null) "$requested_version" \
+        "cd fires PWD hook (single-version fallback): resolves pinned version"
+    cd "$HOME"
+else
+    smoke_pass "pvm install --binary-only fetched $second_version"
 
-mkdir -p "$HOME/proj-a"
-echo "$requested_version" > "$HOME/proj-a/.perl-version"
-cd "$HOME/proj-a"
-smoke_equals (pvm current --bare 2>/dev/null) "$requested_version" \
-    "cd into project resolves via .perl-version (--on-variable PWD hook)"
-set -l cd_front (string split : -- $PATH | head -1)
-smoke_equals "$cd_front" "$XDG_DATA_HOME/pvm/versions/$requested_version/bin" \
-    "cd fires PWD hook — PATH front is pinned version's bin"
-cd "$HOME"
-smoke_pass "cd out of project directory completes cleanly"
+    set -e PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a" "$HOME/proj-b"
+    echo "$requested_version" > "$HOME/proj-a/.perl-version"
+    echo "$second_version"    > "$HOME/proj-b/.perl-version"
+
+    cd "$HOME/proj-a"
+    smoke_equals (pvm current --bare 2>/dev/null) "$requested_version" \
+        "cd into proj-a: PWD hook resolves to $requested_version"
+    smoke_equals (string split : -- $PATH | head -1) \
+                 "$XDG_DATA_HOME/pvm/versions/$requested_version/bin" \
+                 "cd into proj-a: PATH front matches $requested_version's bin"
+
+    cd "$HOME/proj-b"
+    smoke_equals (pvm current --bare 2>/dev/null) "$second_version" \
+        "cd into proj-b: PWD hook resolves to $second_version"
+    smoke_equals (string split : -- $PATH | head -1) \
+                 "$XDG_DATA_HOME/pvm/versions/$second_version/bin" \
+                 "cd into proj-b: PATH front matches $second_version's bin"
+
+    cd "$HOME/proj-a"
+    smoke_equals (string split : -- $PATH | head -1) \
+                 "$XDG_DATA_HOME/pvm/versions/$requested_version/bin" \
+                 "cd back to proj-a: PATH front swings back to $requested_version's bin"
+
+    cd "$HOME"
+end
+rm -f /tmp/install.log
 
 # Completions must register (C2 regression from PR #434). Note: the init
 # template gates the auto-registration on PVM_SKIP_NETWORK_CALLS, which is

--- a/test/docker/smoke-test/journeys/fish-journey.fish
+++ b/test/docker/smoke-test/journeys/fish-journey.fish
@@ -24,7 +24,7 @@ smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 pvm import-system >/dev/null 2>&1
 or smoke_fail "import-system failed"
 
-set -l requested_version (pvm list 2>/dev/null | string match -rg '(5\.[0-9]+\.[0-9]+)' | head -1)
+set -l requested_version (smoke_first_installed_version)
 test -n "$requested_version"
 or smoke_fail "no Perl version found after import-system"
 
@@ -38,15 +38,8 @@ pvm init fish | source
 or smoke_fail "sourcing pvm init fish failed"
 smoke_pass "sourced pvm init fish cleanly"
 
-# `pvm use` / `pvm env activate` modify the shell's env. Running them under
-# `(…)` command substitution puts them in a subshell and the exports are
-# lost. Use a tempfile to inspect output while keeping the env changes.
-set -g pvm_use_log ""
-function pvm_use_run
-    set -g pvm_use_log (mktemp)
-    pvm $argv > $pvm_use_log 2>&1
-end
-
+# pvm_use_run + pvm_use_log live in common.fish — tempfile pattern
+# preserves env exports from pvm in the parent shell.
 pvm_use_run use "$requested_version"
 set -l use_out (cat $pvm_use_log | string collect)
 smoke_contains "$use_out" "Using Perl $requested_version" "pvm use prints Using Perl"
@@ -76,7 +69,7 @@ smoke_pass "pvm use <bogus> short-circuits `; and` chains"
 # Section 3b — G2: cd auto-switch between TWO installed versions
 ############################################################################
 
-set -l second_version "5.40.2"
+set -l second_version "$SMOKE_SECOND_VERSION"
 # CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
 # path until the release workflow ships signed SHA256 checksums. The
 # single-version fallback below still exercises the PWD hook + PATH refresh.

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -1,20 +1,26 @@
 #!/usr/bin/env zsh
 # ABOUTME: Zsh user journey smoke test. Runs inside the smoke-test container.
-# ABOUTME: Mirrors bash-journey.sh with zsh-specific sourcing.
+# ABOUTME: Mirrors bash-journey.sh section-for-section with zsh-specific
+#          sourcing. Sections: presence, setup, use, local, global, use system,
+#          @library / env lifecycle, doctor.
 
 set -u
 source "$(dirname "$0")/common.sh"
 
 echo "=== zsh smoke test ==="
 
-local_help=$(pvm local --help 2>&1)
-smoke_contains "$local_help" "local [version]" "pvm local is a top-level command"
+############################################################################
+# Section 1 — top-level command presence (#432 regression)
+############################################################################
 
-global_help=$(pvm global --help 2>&1)
-smoke_contains "$global_help" "global [version]" "pvm global is a top-level command"
+root_help=$(pvm --help 2>&1)
+smoke_contains "$root_help" "local [version]"  "pvm local is a top-level command"
+smoke_contains "$root_help" "global [version]" "pvm global is a top-level command"
+smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 
-use_help=$(pvm --help 2>&1)
-smoke_contains "$use_help" "use [version" "pvm use listed in root help"
+############################################################################
+# Section 2 — setup
+############################################################################
 
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 
@@ -23,32 +29,143 @@ VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
 
 smoke_setup_stub_perl "$VERSION"
 
+############################################################################
+# Section 3 — pvm use: shell activation (#433 regression)
+############################################################################
+
 # shellcheck disable=SC1090
 source <(pvm init zsh)
 
-pvm use "$VERSION" 2>&1 | grep -q "Using Perl $VERSION" \
-    || smoke_fail "pvm use did not print 'Using Perl $VERSION'"
-smoke_pass "pvm use prints Using Perl"
+# `pvm use` / `pvm env activate` modify the shell env. Running them under
+# a pipe or $(…) puts them in a subshell and the exports are lost.
+pvm_use_log=""
+pvm_use_run() {
+    pvm_use_log=$(mktemp)
+    pvm "$@" > "$pvm_use_log" 2>&1
+}
 
-smoke_equals "$PVM_PERL_VERSION" "$VERSION" "PVM_PERL_VERSION exported"
+pvm_use_run use "$VERSION"
+smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION" "pvm use prints Using Perl"
+rm -f "$pvm_use_log"
 
-front=$(echo "$PATH" | cut -d: -f1)
-smoke_equals "$front" "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
-    "version bin at front of PATH after pvm use"
+smoke_equals "${PVM_PERL_VERSION-}" "$VERSION" "PVM_PERL_VERSION exported"
 
-perl_out=$(perl -v 2>&1 | head -1)
-smoke_contains "$perl_out" "v$VERSION" "perl -v reflects pvm use version"
+smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+             "version bin at front of PATH after pvm use"
+
+smoke_contains "$(perl -v 2>&1 | head -1)" "v$VERSION" \
+               "perl -v reflects pvm use version"
 
 pvm use not-a-real-version >/dev/null 2>&1
-rc=$?
-smoke_exit_eq "$rc" "1" "pvm use <bogus> returns non-zero exit"
+smoke_exit_eq "$?" "1" "pvm use <bogus> returns non-zero exit"
 
-# Shell-level contract: `pvm use <bogus>` must short-circuit an && chain.
 if pvm use not-a-real-version 2>/dev/null; then
     smoke_fail "pvm use <bogus> followed by && should NOT run the next command"
 else
     smoke_pass "pvm use <bogus> short-circuits && chains"
 fi
+
+############################################################################
+# Section 4 — pvm local
+############################################################################
+
+pvm use "$VERSION" >/dev/null 2>&1
+cd "$HOME"
+
+pvm local "$VERSION" 2>&1 | grep -q "Local Perl version set" \
+    || smoke_fail "pvm local did not confirm"
+smoke_pass "pvm local confirms write"
+[ -f "$HOME/.perl-version" ] || smoke_fail "pvm local did not create .perl-version"
+smoke_equals "$(cat "$HOME/.perl-version")" "$VERSION" "pvm local wrote $VERSION"
+
+smoke_contains "$(pvm detect-version 2>&1)" ".perl-version" \
+               "pvm detect-version sees the pin"
+
+pvm local --unset 2>&1 | grep -q "unset" || smoke_fail "pvm local --unset failed"
+[ ! -f "$HOME/.perl-version" ] || smoke_fail "pvm local --unset did not remove file"
+smoke_pass "pvm local --unset removes .perl-version"
+
+############################################################################
+# Section 5 — pvm global
+############################################################################
+
+unset PVM_PERL_VERSION
+
+pvm global "$VERSION" 2>&1 | grep -q "Global Perl version set" \
+    || smoke_fail "pvm global did not confirm"
+smoke_pass "pvm global confirms write"
+smoke_contains "$(pvm current --bare 2>&1)" "$VERSION" \
+               "pvm current --bare reads pvm global"
+
+pvm global --unset 2>&1 | grep -q "unset" || smoke_fail "pvm global --unset failed"
+smoke_pass "pvm global --unset clears default"
+
+############################################################################
+# Section 6 — pvm use system
+############################################################################
+
+pvm use "$VERSION" >/dev/null 2>&1
+smoke_equals "$PVM_PERL_VERSION" "$VERSION" "sanity: version active before use system"
+
+pvm_use_run use system
+smoke_contains "$(cat "$pvm_use_log")" "Using system Perl" \
+               "pvm use system prints 'Using system Perl'"
+rm -f "$pvm_use_log"
+[ -z "${PVM_PERL_VERSION-}" ] || smoke_fail "pvm use system did not clear PVM_PERL_VERSION"
+smoke_pass "pvm use system clears PVM_PERL_VERSION"
+
+############################################################################
+# Section 7 — library environments (regression target: PR #434 I5 was
+#            specifically about the zsh template missing PVM_PERL_LIBRARY
+#            handling in _pvm_update_perl_path)
+############################################################################
+
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/bin"
+mkdir -p "$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5"
+
+smoke_contains "$(pvm env list 2>&1)" "testlib" "pvm env list shows testlib"
+
+pvm_use_run use "$VERSION@testlib"
+smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION@testlib" \
+               "pvm use X@lib prints 'Using Perl X@lib'"
+rm -f "$pvm_use_log"
+smoke_equals "${PVM_PERL_LIBRARY-}" "testlib" "PVM_PERL_LIBRARY exported"
+
+case ":$PATH:" in
+    *":$XDG_DATA_HOME/pvm/environments/testlib/bin:"*)
+        smoke_pass "library bin is on PATH after pvm use X@library" ;;
+    *)
+        smoke_fail "library bin NOT on PATH after pvm use X@library; PATH=$PATH" ;;
+esac
+
+case ":${PERL5LIB:-}:" in
+    *":$XDG_DATA_HOME/pvm/environments/testlib/lib/perl5:"*)
+        smoke_pass "library lib/perl5 is on PERL5LIB after pvm use X@library" ;;
+    *)
+        smoke_fail "library lib/perl5 NOT on PERL5LIB; PERL5LIB=${PERL5LIB:-<unset>}" ;;
+esac
+
+pvm use "$VERSION" >/dev/null 2>&1
+[ -z "${PVM_PERL_LIBRARY:-}" ] || smoke_fail "pvm use X (no @) did not clear PVM_PERL_LIBRARY"
+smoke_pass "pvm use X (no @) clears PVM_PERL_LIBRARY"
+
+rm_out=$(echo y | pvm env remove testlib 2>&1)
+smoke_contains "$rm_out" "has been removed" "pvm env remove confirms removal"
+[ ! -d "$XDG_DATA_HOME/pvm/environments/testlib" ] \
+    || smoke_fail "pvm env remove did not delete the directory"
+smoke_pass "pvm env remove tears the env down"
+
+############################################################################
+# Section 8 — doctor sanity
+############################################################################
+
+doctor_out=$(pvm self doctor 2>&1)
+smoke_exit_eq "$?" "0" "pvm self doctor exits 0 in zsh journey"
+if echo "$doctor_out" | grep -q "Multiple pvm binaries in PATH"; then
+    smoke_fail "self doctor incorrectly flagged stale installs in clean container"
+fi
+smoke_pass "self doctor: no false stale-install warning"
 
 echo ""
 echo "=== zsh smoke test: all assertions passed ==="

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -71,11 +71,19 @@ fi
 ############################################################################
 
 SECOND_VERSION="5.40.2"
-(
-    unset PVM_SKIP_NETWORK_CALLS
-    pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
-)
-install_rc=$?
+# CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
+# path until the release workflow ships signed SHA256 checksums. The
+# single-version fallback below still exercises the cd hook + PATH refresh.
+if [ "${PVM_SMOKE_SKIP_BINARY_INSTALL-}" = "1" ]; then
+    install_rc=1
+    smoke_pass "binary-install gated off (PVM_SMOKE_SKIP_BINARY_INSTALL=1)"
+else
+    (
+        unset PVM_SKIP_NETWORK_CALLS
+        pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
+    )
+    install_rc=$?
+fi
 if [ "$install_rc" -ne 0 ]; then
     smoke_pass "skipping two-version auto-switch (install rc=$install_rc; network?)"
     unset PVM_PERL_VERSION

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -67,6 +67,23 @@ else
 fi
 
 ############################################################################
+# Section 3b — G2: cd auto-switch hook (zsh chpwd)
+############################################################################
+
+unset PVM_PERL_VERSION
+
+mkdir -p "$HOME/proj-a"
+echo "$VERSION" > "$HOME/proj-a/.perl-version"
+cd "$HOME/proj-a"
+smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+             "cd into project resolves via .perl-version (chpwd hook)"
+smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+             "cd fires chpwd hook — PATH front is pinned version's bin"
+cd "$HOME"
+smoke_pass "cd out of project directory completes cleanly"
+
+############################################################################
 # Section 4 — pvm local
 ############################################################################
 

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -156,7 +156,7 @@ smoke_pass "pvm global --unset clears default"
 ############################################################################
 
 pvm use "$VERSION" >/dev/null 2>&1
-smoke_equals "$PVM_PERL_VERSION" "$VERSION" "sanity: version active before use system"
+smoke_equals "${PVM_PERL_VERSION-}" "$VERSION" "sanity: version active before use system"
 
 pvm_use_run use system
 smoke_contains "$(cat "$pvm_use_log")" "Using system Perl" \

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -24,7 +24,7 @@ smoke_contains "$root_help" "use [version"     "pvm use listed in root help"
 
 pvm import-system >/dev/null 2>&1 || smoke_fail "import-system failed"
 
-VERSION=$(pvm list 2>/dev/null | grep -oE '5\.[0-9]+\.[0-9]+' | head -1)
+VERSION=$(smoke_first_installed_version)
 [ -n "$VERSION" ] || smoke_fail "no Perl version found after import-system"
 
 smoke_setup_stub_perl "$VERSION"
@@ -36,14 +36,8 @@ smoke_setup_stub_perl "$VERSION"
 # shellcheck disable=SC1090
 source <(pvm init zsh)
 
-# `pvm use` / `pvm env activate` modify the shell env. Running them under
-# a pipe or $(…) puts them in a subshell and the exports are lost.
-pvm_use_log=""
-pvm_use_run() {
-    pvm_use_log=$(mktemp)
-    pvm "$@" > "$pvm_use_log" 2>&1
-}
-
+# pvm_use_run + pvm_use_log live in common.sh — tempfile pattern preserves
+# env exports from pvm in the parent shell.
 pvm_use_run use "$VERSION"
 smoke_contains "$(cat "$pvm_use_log")" "Using Perl $VERSION" "pvm use prints Using Perl"
 rm -f "$pvm_use_log"
@@ -70,7 +64,7 @@ fi
 # Section 3b — G2: cd auto-switch between TWO installed versions
 ############################################################################
 
-SECOND_VERSION="5.40.2"
+SECOND_VERSION="$SMOKE_SECOND_VERSION"
 # CI sets PVM_SMOKE_SKIP_BINARY_INSTALL=1 to skip the networked binary-fetch
 # path until the release workflow ships signed SHA256 checksums. The
 # single-version fallback below still exercises the cd hook + PATH refresh.

--- a/test/docker/smoke-test/journeys/zsh-journey.sh
+++ b/test/docker/smoke-test/journeys/zsh-journey.sh
@@ -67,21 +67,54 @@ else
 fi
 
 ############################################################################
-# Section 3b — G2: cd auto-switch hook (zsh chpwd)
+# Section 3b — G2: cd auto-switch between TWO installed versions
 ############################################################################
 
-unset PVM_PERL_VERSION
+SECOND_VERSION="5.40.2"
+(
+    unset PVM_SKIP_NETWORK_CALLS
+    pvm install "$SECOND_VERSION" --binary-only >/tmp/install.log 2>&1
+)
+install_rc=$?
+if [ "$install_rc" -ne 0 ]; then
+    smoke_pass "skipping two-version auto-switch (install rc=$install_rc; network?)"
+    unset PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a"
+    echo "$VERSION" > "$HOME/proj-a/.perl-version"
+    cd "$HOME/proj-a"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+                 "cd fires chpwd hook (single-version fallback): resolves pinned version"
+    cd "$HOME"
+else
+    smoke_pass "pvm install --binary-only fetched $SECOND_VERSION"
 
-mkdir -p "$HOME/proj-a"
-echo "$VERSION" > "$HOME/proj-a/.perl-version"
-cd "$HOME/proj-a"
-smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
-             "cd into project resolves via .perl-version (chpwd hook)"
-smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
-             "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
-             "cd fires chpwd hook — PATH front is pinned version's bin"
-cd "$HOME"
-smoke_pass "cd out of project directory completes cleanly"
+    unset PVM_PERL_VERSION
+    mkdir -p "$HOME/proj-a" "$HOME/proj-b"
+    echo "$VERSION"        > "$HOME/proj-a/.perl-version"
+    echo "$SECOND_VERSION" > "$HOME/proj-b/.perl-version"
+
+    cd "$HOME/proj-a"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$VERSION" \
+                 "cd into proj-a: chpwd hook resolves to $VERSION"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+                 "cd into proj-a: PATH front matches $VERSION's bin"
+
+    cd "$HOME/proj-b"
+    smoke_equals "$(pvm current --bare 2>/dev/null)" "$SECOND_VERSION" \
+                 "cd into proj-b: chpwd hook resolves to $SECOND_VERSION"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$SECOND_VERSION/bin" \
+                 "cd into proj-b: PATH front matches $SECOND_VERSION's bin"
+
+    cd "$HOME/proj-a"
+    smoke_equals "$(echo "$PATH" | cut -d: -f1)" \
+                 "$XDG_DATA_HOME/pvm/versions/$VERSION/bin" \
+                 "cd back to proj-a: PATH front swings back to $VERSION's bin"
+
+    cd "$HOME"
+fi
+rm -f /tmp/install.log
 
 ############################################################################
 # Section 4 — pvm local

--- a/test/docker/smoke-test/run-smoke.sh
+++ b/test/docker/smoke-test/run-smoke.sh
@@ -31,14 +31,16 @@ failures=0
 # Run the shell-agnostic suite once (from bash) before the three per-shell
 # journeys. Cheaper than running it three times and keeps the per-shell
 # journey files focused on integration-dependent workflows.
-echo "==> Running core-commands suite (shell-agnostic)"
-if docker run --rm pvm-smoke:latest bash "/smoke/journeys/core-commands.sh"; then
-    echo "   ✓ core-commands suite passed"
-else
-    echo "   ✗ core-commands suite FAILED"
-    failures=$((failures + 1))
-fi
-echo ""
+for suite in core-commands.sh advanced-commands.sh; do
+    echo "==> Running $suite (shell-agnostic)"
+    if docker run --rm pvm-smoke:latest bash "/smoke/journeys/$suite"; then
+        echo "   ✓ $suite passed"
+    else
+        echo "   ✗ $suite FAILED"
+        failures=$((failures + 1))
+    fi
+    echo ""
+done
 
 for shell_script in bash:bash-journey.sh zsh:zsh-journey.sh fish:fish-journey.fish; do
     shell="${shell_script%%:*}"

--- a/test/docker/smoke-test/run-smoke.sh
+++ b/test/docker/smoke-test/run-smoke.sh
@@ -28,12 +28,20 @@ docker build -t pvm-smoke:latest "$here"
 echo ""
 failures=0
 
+# Propagate selected host env vars into each docker run. Callers (CI, or a
+# dev debugging locally) can set PVM_SMOKE_SKIP_BINARY_INSTALL=1 to gate
+# off the two-version binary-install section of Section 3b.
+docker_env_flags=()
+if [ -n "${PVM_SMOKE_SKIP_BINARY_INSTALL-}" ]; then
+    docker_env_flags+=(-e "PVM_SMOKE_SKIP_BINARY_INSTALL=$PVM_SMOKE_SKIP_BINARY_INSTALL")
+fi
+
 # Run the shell-agnostic suite once (from bash) before the three per-shell
 # journeys. Cheaper than running it three times and keeps the per-shell
 # journey files focused on integration-dependent workflows.
 for suite in core-commands.sh advanced-commands.sh; do
     echo "==> Running $suite (shell-agnostic)"
-    if docker run --rm pvm-smoke:latest bash "/smoke/journeys/$suite"; then
+    if docker run --rm "${docker_env_flags[@]}" pvm-smoke:latest bash "/smoke/journeys/$suite"; then
         echo "   ✓ $suite passed"
     else
         echo "   ✗ $suite FAILED"
@@ -46,7 +54,7 @@ for shell_script in bash:bash-journey.sh zsh:zsh-journey.sh fish:fish-journey.fi
     shell="${shell_script%%:*}"
     script="${shell_script#*:}"
     echo "==> Running $shell journey"
-    if docker run --rm pvm-smoke:latest "$shell" "/smoke/journeys/$script"; then
+    if docker run --rm "${docker_env_flags[@]}" pvm-smoke:latest "$shell" "/smoke/journeys/$script"; then
         echo "   ✓ $shell journey passed"
     else
         echo "   ✗ $shell journey FAILED"

--- a/test/docker/smoke-test/run-smoke.sh
+++ b/test/docker/smoke-test/run-smoke.sh
@@ -27,6 +27,19 @@ docker build -t pvm-smoke:latest "$here"
 
 echo ""
 failures=0
+
+# Run the shell-agnostic suite once (from bash) before the three per-shell
+# journeys. Cheaper than running it three times and keeps the per-shell
+# journey files focused on integration-dependent workflows.
+echo "==> Running core-commands suite (shell-agnostic)"
+if docker run --rm pvm-smoke:latest bash "/smoke/journeys/core-commands.sh"; then
+    echo "   ✓ core-commands suite passed"
+else
+    echo "   ✗ core-commands suite FAILED"
+    failures=$((failures + 1))
+fi
+echo ""
+
 for shell_script in bash:bash-journey.sh zsh:zsh-journey.sh fish:fish-journey.fish; do
     shell="${shell_script%%:*}"
     script="${shell_script#*:}"
@@ -41,8 +54,8 @@ for shell_script in bash:bash-journey.sh zsh:zsh-journey.sh fish:fish-journey.fi
 done
 
 if [ "$failures" -gt 0 ]; then
-    echo "==> $failures shell journey(s) failed"
+    echo "==> $failures suite(s) failed"
     exit 1
 fi
 
-echo "==> All shell journeys passed"
+echo "==> All smoke suites passed"


### PR DESCRIPTION
## Summary

Answers the question \"how expansive are the user journey tests?\" — they
were 6 commands / ~25 assertions, now **~20 commands / 128 assertions**
across four modular suites. Went with the modular approach (option B
from the design chat).

## Coverage

| Suite | Assertions | Scope |
|---|---|---|
| \`core-commands.sh\` | 38 | Shell-agnostic: version, --help, list, available, completion, config, env list, remote list, detect-version, self doctor, current/--bare, --help for every top-level cobra command |
| \`bash-journey.sh\` | 29 | Per-shell workflows in bash |
| \`zsh-journey.sh\` | 29 | Per-shell workflows in zsh |
| \`fish-journey.fish\` | 32 | Per-shell workflows in fish + fish-specific template regressions + completion registration |
| **Total** | **128** | ~20 of 31 top-level commands |

The per-shell journeys now have 8 labeled sections: top-level presence
(#432), setup, \`pvm use\` (#433), \`pvm local\` roundtrip, \`pvm global\`
roundtrip, \`pvm use system\`, library environments (\`@library\` + \`env
list\` / \`env remove\`), doctor sanity.

Commands intentionally out of scope: \`install\`, \`build-perl\`,
\`install-perl\`, \`module install\`, \`run\`/pvx, \`psc\` — they need real
Perl + network access and belong in \`test/docker/shell-integration/\`
(Go e2e) or a slow-tier CI job.

## Real template bugs caught

The expanded coverage runs with \`set -u\`, which surfaced pre-existing
bugs in the bash/zsh shell integration templates: unguarded expansions
of \`\$ZSH_VERSION\`, \`\$PVM_EXEC_CACHE\`, \`\$PVM_PERL_LIBRARY\`,
\`\$PERL5LIB\`, \`\$PVM_SKIP_NETWORK_CALLS\` would crash any user shell
with \`set -u\` in effect. Wrapped all of them in \`\${VAR-}\` expansion.
Users without \`set -u\` were unaffected, but this is exactly the kind
of user-reported-class bug the smoke test exists to catch pre-ship.

## Infrastructure

- \`smoke_setup_stub_perl\` helper in \`common.sh\`/\`common.fish\` — was
  duplicated three times.
- \`smoke_contains\` truncates long \`actual\` values in failure output
  (completion scripts were dumping 600 lines on mismatch).
- \`pvm_use_run\` helper in each journey captures output via a tempfile
  rather than a pipe; pipes put \`pvm use\` in a subshell whose env
  exports don't reach the parent.
- \`pvm env remove\` is interactive (\`[y/N]\` prompt); journeys pipe \`y\`
  to confirm.

## Test plan

- [x] All 4 suites pass locally against \`~/.local/bin/pvm\` (rc70).
- [x] Go unit + e2e suites stay green (\`go test ./internal/perl/ ./internal/pvm/ ./test/e2e/\`).
- [ ] Reviewer: run \`make smoke-test\` on a machine with Docker
  installed to verify the four suites run end-to-end in the container.