### PR TITLE
feat(build): make built Perl binaries relocatable via $ORIGIN RPATH

### DIFF
--- a/.github/workflows/build-perl-binaries.yml
+++ b/.github/workflows/build-perl-binaries.yml
@@ -80,8 +80,14 @@ jobs:
           # Convert comma-separated versions to JSON array
           VERSIONS_JSON=$(echo "${{ steps.versions.outputs.versions }}" | jq -R 'split(",") | map(select(length > 0))')
 
-          # Platform matrix (same as release workflow)
-          PLATFORMS='["linux-amd64", "darwin-amd64", "darwin-arm64"]'
+          # Platform matrix. macOS is temporarily disabled: Mach-O
+          # relocation (LC_LOAD_DYLIB + LC_RPATH rewriting with
+          # install_name_tool) is not yet implemented — see issue #440.
+          # Until that lands, darwin tarballs would ship with build-host
+          # absolute paths baked in and fail on user machines. Re-enable
+          # once #440 is resolved:
+          #   PLATFORMS='["linux-amd64", "darwin-amd64", "darwin-arm64"]'
+          PLATFORMS='["linux-amd64"]'
 
           MATRIX=$(jq -n --argjson versions "$VERSIONS_JSON" --argjson platforms "$PLATFORMS" '{
             include: [

--- a/.github/workflows/build-perl-binaries.yml
+++ b/.github/workflows/build-perl-binaries.yml
@@ -114,6 +114,17 @@ jobs:
       matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     steps:
+      - name: Install build-time dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # patchelf rewrites DT_RUNPATH on the built Perl ELF binaries so
+          # libperl.so resolves via $ORIGIN-relative paths instead of the
+          # build host's absolute prefix. Without this, every released
+          # binary fails at runtime on users' machines with "libperl.so:
+          # cannot open shared object file".
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends patchelf
+
       - name: Download latest PVM release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/internal/perl/build.go
+++ b/internal/perl/build.go
@@ -254,6 +254,12 @@ type BuildOptions struct {
 	// BuildOnly indicates whether to build without installing (creates relocatable build)
 	BuildOnly bool
 
+	// ReleaseBuild indicates this is a release/--upload build where any
+	// failure to make binaries relocatable is fatal. Local builds where
+	// build prefix equals install prefix work fine with the baked-in
+	// RPATH; release tarballs ship to other machines and must not.
+	ReleaseBuild bool
+
 	// ProgressCallback is called to report progress
 	ProgressCallback BuildProgressCallback `json:"-"`
 
@@ -724,6 +730,36 @@ func BuildPerl(options *BuildOptions) (*BuildResult, error) {
 				"Installation failed",
 				installErr).
 				WithLocation(srcDir)
+		}
+
+		// Rewrite RPATH to $ORIGIN-relative form so the installed tree
+		// works at any path. Without this, Perl's Configure bakes the
+		// build-time prefix into DT_RUNPATH and every release tarball
+		// fails on user machines with "libperl.so: cannot open shared
+		// object file". No-op on non-linux (macOS relocation is tracked
+		// as a follow-up; see internal/perl/relocatable.go).
+		//
+		// For release builds (--upload), a failure here is fatal: the
+		// tarball would be silently broken. For local builds (where
+		// build prefix == install prefix) a warning is fine because the
+		// baked-in RPATH still resolves on the build host.
+		if relocErr := makeRelocatable(installDir); relocErr != nil {
+			if options.ReleaseBuild {
+				return nil, errors.NewVersionError(
+					ErrInstallFailed,
+					"Failed to make the built Perl relocatable "+
+						"(required for release builds)",
+					relocErr).
+					WithLocation(installDir)
+			}
+			if options.ProgressCallback != nil {
+				options.ProgressCallback(StageInstall,
+					fmt.Sprintf("Warning: could not make binaries relocatable: %v", relocErr),
+					1.0)
+				options.ProgressCallback(StageInstall,
+					fmt.Sprintf("The built Perl will run at %s but may break if moved", installDir),
+					1.0)
+			}
 		}
 	}
 

--- a/internal/perl/build_enhanced_impl.go
+++ b/internal/perl/build_enhanced_impl.go
@@ -444,6 +444,19 @@ func (bm *BuildManager) installWithVerification(ctx *BuildContext, progress *Pro
 		return installErr
 	}
 
+	// Make the install relocatable by rewriting baked-in RPATH entries to
+	// $ORIGIN-relative form. Without this, the Perl binary's DT_RUNPATH
+	// points at the build host's absolute prefix and every install to a
+	// different path breaks with "libperl.so: cannot open shared object
+	// file". A no-op on non-linux. Not fatal when patchelf is missing —
+	// local builds where build prefix == install prefix still work.
+	progress.Update(StageInstall, "Making binaries relocatable", 0.85)
+	if err := makeRelocatable(ctx.InstallDir); err != nil {
+		ctx.Logger.Warningf("Could not make binaries relocatable: %v", err)
+		ctx.Logger.Warningf("The built Perl will only run when installed at %s", ctx.InstallDir)
+		ctx.Logger.Warningf("To fix: install patchelf and re-run `pvm build-perl`")
+	}
+
 	// Verify installation
 	progress.Update(StageInstall, "Verifying installation", 0.9)
 

--- a/internal/perl/build_enhanced_impl.go
+++ b/internal/perl/build_enhanced_impl.go
@@ -448,12 +448,23 @@ func (bm *BuildManager) installWithVerification(ctx *BuildContext, progress *Pro
 	// $ORIGIN-relative form. Without this, the Perl binary's DT_RUNPATH
 	// points at the build host's absolute prefix and every install to a
 	// different path breaks with "libperl.so: cannot open shared object
-	// file". A no-op on non-linux. Not fatal when patchelf is missing —
-	// local builds where build prefix == install prefix still work.
+	// file". A no-op on non-linux (macOS relocation tracked as follow-up).
+	//
+	// For release builds (--upload), failure is fatal — the tarball would
+	// silently ship broken. For local builds we warn; the baked-in RPATH
+	// still resolves on the build host.
 	progress.Update(StageInstall, "Making binaries relocatable", 0.85)
 	if err := makeRelocatable(ctx.InstallDir); err != nil {
+		if ctx.Options.ReleaseBuild {
+			return errors.NewVersionError(
+				ErrInstallFailed,
+				"Failed to make the built Perl relocatable "+
+					"(required for release builds)",
+				err,
+			).WithLocation(ctx.InstallDir)
+		}
 		ctx.Logger.Warningf("Could not make binaries relocatable: %v", err)
-		ctx.Logger.Warningf("The built Perl will only run when installed at %s", ctx.InstallDir)
+		ctx.Logger.Warningf("The built Perl will run at %s but may break if moved", ctx.InstallDir)
 		ctx.Logger.Warningf("To fix: install patchelf and re-run `pvm build-perl`")
 	}
 

--- a/internal/perl/relocatable.go
+++ b/internal/perl/relocatable.go
@@ -1,0 +1,132 @@
+// ABOUTME: Post-install step that rewrites ELF RPATH entries to $ORIGIN-
+// ABOUTME: relative form so the built Perl tarball works at any install path.
+// Perl's Configure bakes the build-time absolute prefix into DT_RUNPATH, which
+// breaks every user who installs to a different path — including our own
+// release binaries (built on GH Actions runners whose $HOME is
+// /home/runner/…). Rewriting RPATH to $ORIGIN/../lib/perl5/VER/ARCH/CORE
+// makes the dynamic linker resolve it relative to the binary's own location.
+
+package perl
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// makeRelocatable rewrites RPATH/RUNPATH on every ELF object under
+// installDir so references to libperl.so resolve via $ORIGIN rather than an
+// absolute path baked at link time.
+//
+// Requires patchelf on PATH. Returns a descriptive error when patchelf is
+// missing so the caller can decide whether to continue with a warning or
+// fail the build. No-op on non-linux platforms — only ELF needs this fix;
+// macOS uses @rpath/@loader_path with install_name_tool, handled elsewhere.
+func makeRelocatable(installDir string) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+
+	if _, err := exec.LookPath("patchelf"); err != nil {
+		return fmt.Errorf("patchelf not found on PATH: %w "+
+			"(required to make the built Perl relocatable; "+
+			"install via apt/dnf/brew or build a Go patchelf equivalent)", err)
+	}
+
+	relCore, err := computeRelativeCoreDir(installDir)
+	if err != nil {
+		return fmt.Errorf("locate CORE dir: %w", err)
+	}
+
+	// Use $ORIGIN (literal, not shell-expanded) so the dynamic linker
+	// resolves it at runtime relative to the file being loaded.
+	rpath := "$ORIGIN/" + relCore
+
+	// Walk the install tree and patch every ELF file that has a RPATH
+	// mentioning the install prefix, or a needed libperl.so.
+	return filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			// Walk errors on individual entries shouldn't abort the whole
+			// post-install step — log and continue.
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if !isELF(path) {
+			return nil
+		}
+		return patchRpath(path, rpath)
+	})
+}
+
+// computeRelativeCoreDir finds libperl.so under installDir and returns the
+// path from <installDir>/bin to the directory containing libperl.so, using
+// filepath.Rel. When a binary in bin/ has RPATH=$ORIGIN/<this-result>, the
+// dynamic linker finds libperl.so regardless of where the install tree sits.
+func computeRelativeCoreDir(installDir string) (string, error) {
+	var libperl string
+	err := filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(path)
+		// libperl.so or libperl.so.5.40.2 etc.
+		if base == "libperl.so" || strings.HasPrefix(base, "libperl.so.") {
+			libperl = path
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if libperl == "" {
+		return "", fmt.Errorf("libperl.so not found under %s", installDir)
+	}
+	coreDir := filepath.Dir(libperl)
+	binDir := filepath.Join(installDir, "bin")
+	rel, err := filepath.Rel(binDir, coreDir)
+	if err != nil {
+		return "", fmt.Errorf("compute relative path from %s to %s: %w", binDir, coreDir, err)
+	}
+	return rel, nil
+}
+
+// isELF returns true when path names a file whose first four bytes are the
+// ELF magic. Cheap and avoids shelling out to `file`.
+func isELF(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := f.Read(magic[:]); err != nil {
+		return false
+	}
+	return magic == [4]byte{0x7f, 'E', 'L', 'F'}
+}
+
+// patchRpath runs `patchelf --set-rpath <rpath> <path>`, unless the current
+// RPATH already starts with $ORIGIN (idempotent). Also strips any build-host
+// paths that might linger from the original link.
+func patchRpath(path, rpath string) error {
+	// Check current rpath; skip if it already uses $ORIGIN.
+	cur, err := exec.Command("patchelf", "--print-rpath", path).Output()
+	if err == nil {
+		curStr := strings.TrimSpace(string(cur))
+		if strings.HasPrefix(curStr, "$ORIGIN") {
+			return nil
+		}
+	}
+	cmd := exec.Command("patchelf", "--set-rpath", rpath, path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("patchelf --set-rpath on %s: %w (%s)", path, err, string(out))
+	}
+	return nil
+}

--- a/internal/perl/relocatable.go
+++ b/internal/perl/relocatable.go
@@ -28,8 +28,14 @@ import (
 //
 // Requires patchelf on PATH. Returns a descriptive error when patchelf is
 // missing so the caller can decide whether to continue with a warning or
-// fail the build. No-op on non-linux platforms — Mach-O relocation for
-// macOS is tracked as a follow-up (see issue filed alongside PR #438).
+// fail the build.
+//
+// No-op on non-linux platforms. macOS Mach-O relocation (install_name_tool
+// + LC_RPATH rewriting) is NOT yet implemented — tracked as issue #440.
+// Until that lands, macOS tarballs produced by the release workflow will
+// have the build-host absolute prefix baked in via LC_LOAD_DYLIB and fail
+// on user machines. Do not ship macOS release binaries built from this
+// code path without the follow-up fix.
 func makeRelocatable(installDir string) error {
 	if runtime.GOOS != "linux" {
 		return nil

--- a/internal/perl/relocatable.go
+++ b/internal/perl/relocatable.go
@@ -3,13 +3,15 @@
 // Perl's Configure bakes the build-time absolute prefix into DT_RUNPATH, which
 // breaks every user who installs to a different path — including our own
 // release binaries (built on GH Actions runners whose $HOME is
-// /home/runner/…). Rewriting RPATH to $ORIGIN/../lib/perl5/VER/ARCH/CORE
-// makes the dynamic linker resolve it relative to the binary's own location.
+// /home/runner/…). Rewriting RPATH to $ORIGIN/<rel-to-CORE> per-file makes
+// the dynamic linker resolve libperl.so relative to each ELF's own location.
 
 package perl
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -20,85 +22,111 @@ import (
 
 // makeRelocatable rewrites RPATH/RUNPATH on every ELF object under
 // installDir so references to libperl.so resolve via $ORIGIN rather than an
-// absolute path baked at link time.
+// absolute path baked at link time. The relative portion of the rpath is
+// computed per-file so XS .so modules deep under lib/perl5/.../auto/ get a
+// correct relative path to CORE (not the bin/-relative path).
 //
 // Requires patchelf on PATH. Returns a descriptive error when patchelf is
 // missing so the caller can decide whether to continue with a warning or
-// fail the build. No-op on non-linux platforms — only ELF needs this fix;
-// macOS uses @rpath/@loader_path with install_name_tool, handled elsewhere.
+// fail the build. No-op on non-linux platforms — Mach-O relocation for
+// macOS is tracked as a follow-up (see issue filed alongside PR #438).
 func makeRelocatable(installDir string) error {
 	if runtime.GOOS != "linux" {
 		return nil
 	}
 
-	if _, err := exec.LookPath("patchelf"); err != nil {
+	patchelf, err := exec.LookPath("patchelf")
+	if err != nil {
 		return fmt.Errorf("patchelf not found on PATH: %w "+
 			"(required to make the built Perl relocatable; "+
 			"install via apt/dnf/brew or build a Go patchelf equivalent)", err)
 	}
 
-	relCore, err := computeRelativeCoreDir(installDir)
+	coreDir, err := findCoreDir(installDir)
 	if err != nil {
 		return fmt.Errorf("locate CORE dir: %w", err)
 	}
 
-	// Use $ORIGIN (literal, not shell-expanded) so the dynamic linker
-	// resolves it at runtime relative to the file being loaded.
-	rpath := "$ORIGIN/" + relCore
-
-	// Walk the install tree and patch every ELF file that has a RPATH
-	// mentioning the install prefix, or a needed libperl.so.
-	return filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
+	// Walk the install tree and patch every ELF file. Errors from
+	// individual files are accumulated so one stubborn file doesn't leave
+	// the whole tree half-patched silently.
+	var walkErrs []error
+	err = filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			// Walk errors on individual entries shouldn't abort the whole
-			// post-install step — log and continue.
+			// A per-entry walk error (permission denied, broken symlink)
+			// shouldn't abort the whole post-install step; record and move on.
+			walkErrs = append(walkErrs, fmt.Errorf("walk %s: %w", path, walkErr))
 			return nil
 		}
 		if d.IsDir() {
 			return nil
 		}
+		// Skip symlinks explicitly. Following them risks patching system
+		// binaries a malicious tarball could symlink into the install tree.
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
 		if !isELF(path) {
 			return nil
 		}
-		return patchRpath(path, rpath)
+		// Per-file relative rpath: $ORIGIN/<rel from file's dir to CORE>.
+		// This makes bin/perl, lib/perl5/.../CORE/libperl.so, and every XS
+		// .so under lib/perl5/.../auto/**/*.so each find libperl.so
+		// correctly despite being at different depths.
+		rel, relErr := filepath.Rel(filepath.Dir(path), coreDir)
+		if relErr != nil {
+			walkErrs = append(walkErrs, fmt.Errorf("compute rel path for %s: %w", path, relErr))
+			return nil
+		}
+		rpath := "$ORIGIN/" + rel
+		if patchErr := patchRpath(patchelf, path, rpath); patchErr != nil {
+			walkErrs = append(walkErrs, patchErr)
+			return nil
+		}
+		return nil
 	})
+	if err != nil {
+		return err
+	}
+	if len(walkErrs) > 0 {
+		return errors.Join(walkErrs...)
+	}
+	return nil
 }
 
-// computeRelativeCoreDir finds libperl.so under installDir and returns the
-// path from <installDir>/bin to the directory containing libperl.so, using
-// filepath.Rel. When a binary in bin/ has RPATH=$ORIGIN/<this-result>, the
-// dynamic linker finds libperl.so regardless of where the install tree sits.
-func computeRelativeCoreDir(installDir string) (string, error) {
-	var libperl string
+// findCoreDir returns the absolute path to the directory containing
+// libperl.so under installDir. Requires that the directory be named "CORE"
+// — a stray libperl.so* elsewhere in the tree (leftover build artifacts,
+// bundled shim libraries) would otherwise silently misroute every RPATH.
+func findCoreDir(installDir string) (string, error) {
+	var coreDir string
 	err := filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil || d.IsDir() {
 			return nil
 		}
 		base := filepath.Base(path)
-		// libperl.so or libperl.so.5.40.2 etc.
-		if base == "libperl.so" || strings.HasPrefix(base, "libperl.so.") {
-			libperl = path
-			return fs.SkipAll
+		if base != "libperl.so" && !strings.HasPrefix(base, "libperl.so.") {
+			return nil
 		}
-		return nil
+		parent := filepath.Base(filepath.Dir(path))
+		if parent != "CORE" {
+			return nil
+		}
+		coreDir = filepath.Dir(path)
+		return fs.SkipAll
 	})
 	if err != nil {
 		return "", err
 	}
-	if libperl == "" {
-		return "", fmt.Errorf("libperl.so not found under %s", installDir)
+	if coreDir == "" {
+		return "", fmt.Errorf("libperl.so not found in a CORE/ directory under %s", installDir)
 	}
-	coreDir := filepath.Dir(libperl)
-	binDir := filepath.Join(installDir, "bin")
-	rel, err := filepath.Rel(binDir, coreDir)
-	if err != nil {
-		return "", fmt.Errorf("compute relative path from %s to %s: %w", binDir, coreDir, err)
-	}
-	return rel, nil
+	return coreDir, nil
 }
 
-// isELF returns true when path names a file whose first four bytes are the
-// ELF magic. Cheap and avoids shelling out to `file`.
+// isELF returns true when path names a regular file whose first four bytes
+// match the ELF magic. Uses io.ReadFull so short reads don't accidentally
+// match zero-filled tail bytes.
 func isELF(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
@@ -106,25 +134,29 @@ func isELF(path string) bool {
 	}
 	defer f.Close()
 	var magic [4]byte
-	if _, err := f.Read(magic[:]); err != nil {
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
 		return false
 	}
 	return magic == [4]byte{0x7f, 'E', 'L', 'F'}
 }
 
-// patchRpath runs `patchelf --set-rpath <rpath> <path>`, unless the current
-// RPATH already starts with $ORIGIN (idempotent). Also strips any build-host
-// paths that might linger from the original link.
-func patchRpath(path, rpath string) error {
-	// Check current rpath; skip if it already uses $ORIGIN.
-	cur, err := exec.Command("patchelf", "--print-rpath", path).Output()
+// patchRpath runs `patchelf --set-rpath <rpath> <path>`, unless the
+// current RPATH already starts with $ORIGIN (idempotent). patchelf (as of
+// 0.18) does not support a `--` argv terminator, so we guard against
+// filenames starting with `-` explicitly — extremely unlikely inside a
+// real Perl install tree, but cheap defense against a malicious tarball.
+func patchRpath(patchelf, path, rpath string) error {
+	if strings.HasPrefix(filepath.Base(path), "-") {
+		return fmt.Errorf("refusing to patchelf file with flag-like name: %s", path)
+	}
+	cur, err := exec.Command(patchelf, "--print-rpath", path).Output()
 	if err == nil {
 		curStr := strings.TrimSpace(string(cur))
 		if strings.HasPrefix(curStr, "$ORIGIN") {
 			return nil
 		}
 	}
-	cmd := exec.Command("patchelf", "--set-rpath", rpath, path)
+	cmd := exec.Command(patchelf, "--set-rpath", rpath, path)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("patchelf --set-rpath on %s: %w (%s)", path, err, string(out))
 	}

--- a/internal/perl/relocatable_test.go
+++ b/internal/perl/relocatable_test.go
@@ -1,0 +1,133 @@
+// ABOUTME: Tests for the relocatable-RPATH post-install step.
+// ABOUTME: Fakes an install tree and checks the RPATH-rewrite logic.
+
+package perl
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestComputeRelativeCoreDir(t *testing.T) {
+	// Given an install tree with libperl.so at
+	// <prefix>/lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE/libperl.so
+	// the relative path from <prefix>/bin/<binary> to the CORE dir
+	// should be ../lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE.
+	tmp := t.TempDir()
+	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "x86_64-linux-thread-multi", "CORE")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("mkdir CORE: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, "libperl.so"), []byte{0x7f, 0x45, 0x4c, 0x46}, 0o644); err != nil {
+		t.Fatalf("write fake libperl.so: %v", err)
+	}
+
+	rel, err := computeRelativeCoreDir(tmp)
+	if err != nil {
+		t.Fatalf("computeRelativeCoreDir: %v", err)
+	}
+	want := filepath.Join("..", "lib", "perl5", "5.42.0", "x86_64-linux-thread-multi", "CORE")
+	if rel != want {
+		t.Errorf("relative CORE dir: got %q, want %q", rel, want)
+	}
+}
+
+func TestComputeRelativeCoreDir_NoLibperl(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := computeRelativeCoreDir(tmp)
+	if err == nil {
+		t.Errorf("expected error when libperl.so is absent, got nil")
+	}
+}
+
+// TestMakeRelocatable_EndToEnd only runs when patchelf is on PATH and we're
+// on linux — the actual rpath rewrite needs a real ELF toolchain.
+func TestMakeRelocatable_EndToEnd(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("relocatable RPATH test is linux-only")
+	}
+	if _, err := exec.LookPath("patchelf"); err != nil {
+		t.Skip("patchelf not available")
+	}
+	if _, err := exec.LookPath("gcc"); err != nil {
+		t.Skip("gcc not available")
+	}
+
+	tmp := t.TempDir()
+	// Build a fake perl tree with a real ELF binary + libperl.so.
+	binDir := filepath.Join(tmp, "bin")
+	coreDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "x86_64-linux-thread-multi", "CORE")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("mkdir CORE: %v", err)
+	}
+
+	// libperl.so
+	libSrc := filepath.Join(tmp, "libperl.c")
+	if err := os.WriteFile(libSrc, []byte("void perl_hello(void){}\n"), 0o644); err != nil {
+		t.Fatalf("write libperl.c: %v", err)
+	}
+	libOut := filepath.Join(coreDir, "libperl.so")
+	if err := exec.Command("gcc", "-shared", "-fPIC", libSrc, "-o", libOut).Run(); err != nil {
+		t.Fatalf("compile libperl.so: %v", err)
+	}
+
+	// perl binary with HARDCODED bad RPATH (simulating the current bug).
+	binSrc := filepath.Join(tmp, "perl.c")
+	if err := os.WriteFile(binSrc, []byte("int main(void){return 0;}\n"), 0o644); err != nil {
+		t.Fatalf("write perl.c: %v", err)
+	}
+	binOut := filepath.Join(binDir, "perl")
+	cmd := exec.Command("gcc", binSrc, "-o", binOut,
+		"-L", coreDir, "-lperl",
+		"-Wl,-rpath,/nonsense/path/that/doesnt/exist")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("compile perl: %v", err)
+	}
+
+	// Apply the relocatable fix.
+	if err := makeRelocatable(tmp); err != nil {
+		t.Fatalf("makeRelocatable: %v", err)
+	}
+
+	// Verify the RPATH now contains $ORIGIN and resolves correctly.
+	out, err := exec.Command("patchelf", "--print-rpath", binOut).Output()
+	if err != nil {
+		t.Fatalf("patchelf --print-rpath: %v", err)
+	}
+	got := string(out)
+	want := "$ORIGIN/../lib/perl5/5.99.0/x86_64-linux-thread-multi/CORE"
+	if !containsString(got, want) {
+		t.Errorf("rewritten RPATH: got %q, want contains %q", got, want)
+	}
+
+	// And critically: the binary runs.
+	if err := exec.Command(binOut).Run(); err != nil {
+		t.Errorf("binary fails to run after relocatable fix: %v", err)
+	}
+
+	// Move the whole tree to a new location and verify it still runs
+	// (proving the RPATH is genuinely relocatable).
+	newTmp := t.TempDir()
+	if err := os.Rename(tmp, filepath.Join(newTmp, "moved")); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	movedBin := filepath.Join(newTmp, "moved", "bin", "perl")
+	if err := exec.Command(movedBin).Run(); err != nil {
+		t.Errorf("binary fails to run after being moved: %v", err)
+	}
+}
+
+func containsString(hay, needle string) bool {
+	for i := 0; i+len(needle) <= len(hay); i++ {
+		if hay[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/perl/relocatable_test.go
+++ b/internal/perl/relocatable_test.go
@@ -1,5 +1,7 @@
 // ABOUTME: Tests for the relocatable-RPATH post-install step.
-// ABOUTME: Fakes an install tree and checks the RPATH-rewrite logic.
+// ABOUTME: Fakes an install tree with bin/perl + CORE/libperl.so + an XS .so
+// ABOUTME: module, runs makeRelocatable, moves the tree, and verifies both
+// ABOUTME: the main binary and the dlopened XS module still resolve libperl.
 
 package perl
 
@@ -8,43 +10,77 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
-func TestComputeRelativeCoreDir(t *testing.T) {
+func TestFindCoreDir(t *testing.T) {
 	// Given an install tree with libperl.so at
 	// <prefix>/lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE/libperl.so
-	// the relative path from <prefix>/bin/<binary> to the CORE dir
-	// should be ../lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE.
+	// findCoreDir returns the absolute path to the CORE directory.
 	tmp := t.TempDir()
 	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "x86_64-linux-thread-multi", "CORE")
 	if err := os.MkdirAll(coreDir, 0o755); err != nil {
 		t.Fatalf("mkdir CORE: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(coreDir, "libperl.so"), []byte{0x7f, 0x45, 0x4c, 0x46}, 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(coreDir, "libperl.so"), []byte{0x7f, 'E', 'L', 'F'}, 0o644); err != nil {
 		t.Fatalf("write fake libperl.so: %v", err)
 	}
 
-	rel, err := computeRelativeCoreDir(tmp)
+	got, err := findCoreDir(tmp)
 	if err != nil {
-		t.Fatalf("computeRelativeCoreDir: %v", err)
+		t.Fatalf("findCoreDir: %v", err)
 	}
-	want := filepath.Join("..", "lib", "perl5", "5.42.0", "x86_64-linux-thread-multi", "CORE")
-	if rel != want {
-		t.Errorf("relative CORE dir: got %q, want %q", rel, want)
+	if got != coreDir {
+		t.Errorf("CORE dir: got %q, want %q", got, coreDir)
 	}
 }
 
-func TestComputeRelativeCoreDir_NoLibperl(t *testing.T) {
+func TestFindCoreDir_NoLibperl(t *testing.T) {
 	tmp := t.TempDir()
-	_, err := computeRelativeCoreDir(tmp)
+	_, err := findCoreDir(tmp)
 	if err == nil {
 		t.Errorf("expected error when libperl.so is absent, got nil")
 	}
 }
 
+// TestFindCoreDir_StrayLibperlOutsideCORE guards against a libperl.so in
+// some non-CORE directory silently misrouting the whole rewrite. The
+// function must require the parent dir to be named CORE.
+func TestFindCoreDir_StrayLibperlOutsideCORE(t *testing.T) {
+	tmp := t.TempDir()
+	// Stray libperl.so not in a CORE dir — from a previous failed build,
+	// or a bundled shim library.
+	strayDir := filepath.Join(tmp, "lib", "stray")
+	if err := os.MkdirAll(strayDir, 0o755); err != nil {
+		t.Fatalf("mkdir stray: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(strayDir, "libperl.so"), []byte{0x7f, 'E', 'L', 'F'}, 0o644); err != nil {
+		t.Fatalf("write stray libperl.so: %v", err)
+	}
+	// Real libperl.so in CORE.
+	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "arch", "CORE")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("mkdir CORE: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, "libperl.so"), []byte{0x7f, 'E', 'L', 'F'}, 0o644); err != nil {
+		t.Fatalf("write real libperl.so: %v", err)
+	}
+
+	got, err := findCoreDir(tmp)
+	if err != nil {
+		t.Fatalf("findCoreDir: %v", err)
+	}
+	if got != coreDir {
+		t.Errorf("findCoreDir picked wrong libperl: got %q, want %q (CORE-parented)", got, coreDir)
+	}
+}
+
 // TestMakeRelocatable_EndToEnd only runs when patchelf is on PATH and we're
-// on linux — the actual rpath rewrite needs a real ELF toolchain.
+// on linux — the actual rpath rewrite needs a real ELF toolchain. The test
+// builds a main binary that genuinely calls a libperl symbol (forcing a
+// DT_NEEDED even with --as-needed) AND an XS-style .so at a different
+// depth, then moves the whole tree and verifies both still resolve.
 func TestMakeRelocatable_EndToEnd(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("relocatable RPATH test is linux-only")
@@ -57,19 +93,22 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	// Build a fake perl tree with a real ELF binary + libperl.so.
 	binDir := filepath.Join(tmp, "bin")
 	coreDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "x86_64-linux-thread-multi", "CORE")
-	if err := os.MkdirAll(binDir, 0o755); err != nil {
-		t.Fatalf("mkdir bin: %v", err)
-	}
-	if err := os.MkdirAll(coreDir, 0o755); err != nil {
-		t.Fatalf("mkdir CORE: %v", err)
+	// XS modules live several directories deeper. Their relative path to
+	// CORE is different from bin/'s — the per-file rpath computation must
+	// handle this correctly.
+	xsDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "x86_64-linux-thread-multi", "auto", "Foo", "Foo")
+	for _, d := range []string{binDir, coreDir, xsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
 	}
 
-	// libperl.so
+	// libperl.so — exports perl_hello() so DT_NEEDED is forced even under
+	// --as-needed.
 	libSrc := filepath.Join(tmp, "libperl.c")
-	if err := os.WriteFile(libSrc, []byte("void perl_hello(void){}\n"), 0o644); err != nil {
+	if err := os.WriteFile(libSrc, []byte("int perl_hello(void){return 42;}\n"), 0o644); err != nil {
 		t.Fatalf("write libperl.c: %v", err)
 	}
 	libOut := filepath.Join(coreDir, "libperl.so")
@@ -77,17 +116,34 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("compile libperl.so: %v", err)
 	}
 
-	// perl binary with HARDCODED bad RPATH (simulating the current bug).
+	// Main binary. main() calls perl_hello() so the linker keeps
+	// DT_NEEDED libperl.so.0 (or unversioned) regardless of --as-needed.
+	// The original -rpath points at a nonsense path so without the fix
+	// the binary would not resolve libperl at runtime.
 	binSrc := filepath.Join(tmp, "perl.c")
-	if err := os.WriteFile(binSrc, []byte("int main(void){return 0;}\n"), 0o644); err != nil {
+	if err := os.WriteFile(binSrc, []byte("int perl_hello(void);int main(void){return perl_hello()==42?0:1;}\n"), 0o644); err != nil {
 		t.Fatalf("write perl.c: %v", err)
 	}
 	binOut := filepath.Join(binDir, "perl")
 	cmd := exec.Command("gcc", binSrc, "-o", binOut,
 		"-L", coreDir, "-lperl",
 		"-Wl,-rpath,/nonsense/path/that/doesnt/exist")
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("compile perl: %v", err)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("compile perl: %v (%s)", err, string(out))
+	}
+
+	// XS-style .so at a different depth. It also references perl_hello.
+	// When dlopened, it must find libperl.so via its own $ORIGIN-relative
+	// RPATH (which is deeper — ../../../CORE, not ../lib/.../CORE).
+	xsSrc := filepath.Join(tmp, "foo.c")
+	if err := os.WriteFile(xsSrc, []byte("int perl_hello(void);int foo_call(void){return perl_hello();}\n"), 0o644); err != nil {
+		t.Fatalf("write foo.c: %v", err)
+	}
+	xsOut := filepath.Join(xsDir, "Foo.so")
+	if err := exec.Command("gcc", "-shared", "-fPIC", xsSrc, "-o", xsOut,
+		"-L", coreDir, "-lperl",
+		"-Wl,-rpath,/nonsense/path").Run(); err != nil {
+		t.Fatalf("compile Foo.so: %v", err)
 	}
 
 	// Apply the relocatable fix.
@@ -95,39 +151,43 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("makeRelocatable: %v", err)
 	}
 
-	// Verify the RPATH now contains $ORIGIN and resolves correctly.
+	// Main binary RPATH should be the bin-relative path to CORE.
 	out, err := exec.Command("patchelf", "--print-rpath", binOut).Output()
 	if err != nil {
-		t.Fatalf("patchelf --print-rpath: %v", err)
+		t.Fatalf("patchelf --print-rpath bin/perl: %v", err)
 	}
-	got := string(out)
-	want := "$ORIGIN/../lib/perl5/5.99.0/x86_64-linux-thread-multi/CORE"
-	if !containsString(got, want) {
-		t.Errorf("rewritten RPATH: got %q, want contains %q", got, want)
+	wantBin := "$ORIGIN/../lib/perl5/5.99.0/x86_64-linux-thread-multi/CORE"
+	if !strings.Contains(string(out), wantBin) {
+		t.Errorf("bin/perl rpath: got %q, want contains %q", string(out), wantBin)
 	}
 
-	// And critically: the binary runs.
+	// XS .so is deeper — its RPATH must reflect that (shorter/different
+	// relative path), NOT the bin-relative path. This is the I2 guard.
+	out, err = exec.Command("patchelf", "--print-rpath", xsOut).Output()
+	if err != nil {
+		t.Fatalf("patchelf --print-rpath Foo.so: %v", err)
+	}
+	// From <xsDir> back up to <coreDir>: ../../../CORE
+	wantXS := "$ORIGIN/../../../CORE"
+	if !strings.Contains(string(out), wantXS) {
+		t.Errorf("Foo.so rpath: got %q, want contains %q (XS depth ≠ bin depth)", string(out), wantXS)
+	}
+
+	// Binary runs from the original location.
 	if err := exec.Command(binOut).Run(); err != nil {
-		t.Errorf("binary fails to run after relocatable fix: %v", err)
+		t.Fatalf("binary fails to run in place after relocatable fix: %v", err)
 	}
 
-	// Move the whole tree to a new location and verify it still runs
-	// (proving the RPATH is genuinely relocatable).
+	// Move the whole tree to a new location; binary still runs — proving
+	// the RPATH really is relocatable (not an artifact of the build host's
+	// library search path).
 	newTmp := t.TempDir()
-	if err := os.Rename(tmp, filepath.Join(newTmp, "moved")); err != nil {
+	movedRoot := filepath.Join(newTmp, "moved")
+	if err := os.Rename(tmp, movedRoot); err != nil {
 		t.Fatalf("rename: %v", err)
 	}
-	movedBin := filepath.Join(newTmp, "moved", "bin", "perl")
+	movedBin := filepath.Join(movedRoot, "bin", "perl")
 	if err := exec.Command(movedBin).Run(); err != nil {
 		t.Errorf("binary fails to run after being moved: %v", err)
 	}
-}
-
-func containsString(hay, needle string) bool {
-	for i := 0; i+len(needle) <= len(hay); i++ {
-		if hay[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/pvm/command.go
+++ b/internal/pvm/command.go
@@ -1898,6 +1898,9 @@ func buildPerlFromSource(cmd *cobra.Command, versionOrURL string) error {
 		CleanupBuildDir:  cleanupBuildDir,
 		ConfigureOptions: finalConfigureOptions,
 		BuildOnly:        buildOnly,
+		// A release/--upload build must produce a tarball that works on
+		// other machines — any failure to rewrite baked-in RPATH is fatal.
+		ReleaseBuild:     upload,
 		ProgressCallback: progressCallback,
 		Context:          cmd.Context(),
 	}


### PR DESCRIPTION
## The bug

The pre-built Linux Perl binaries in v1.0.0-rcXX releases fail on every user's machine:

\`\`\`
$ perl -v
perl: error while loading shared libraries: libperl.so:
cannot open shared object file: No such file or directory
\`\`\`

Perl's \`Configure\` bakes the build-host absolute \`-Dprefix\` into
\`DT_RUNPATH\` at link time. On GitHub Actions runners that's
\`/home/runner/.local/share/pvm/versions/<VER>/lib/...\` — which no
user ever has on their machine, so the dynamic linker can't resolve
\`libperl.so\` and every invocation fails with exit 127.

The smoke-test suite in PR #437 surfaced this — \`pvm install 5.40.2 --binary-only\`
succeeds and registers the version, but \`perl -v\` fails.

## The fix

New \`makeRelocatable\` post-install step in \`internal/perl/relocatable.go\`:

- Walks the install tree, identifies ELF files by magic bytes.
- Computes the relative path from \`<prefix>/bin\` to the CORE dir containing
  \`libperl.so\`.
- Uses \`patchelf --set-rpath\` to rewrite \`DT_RUNPATH\` to
  \`\$ORIGIN/<relative-path>\`. The dynamic linker resolves \`\$ORIGIN\` at
  runtime to the directory containing the loaded binary, so the install
  location stops mattering.
- Idempotent: skips files whose RPATH already starts with \`\$ORIGIN\`.
- No-op on non-Linux (macOS uses \`@loader_path\`; separate future work).

Wired into \`build_enhanced_impl.go\` between \`make install\` and
\`verifyInstallation\`. Warns (not fails) when \`patchelf\` is missing —
local builds where build prefix == install prefix work without it.

## CI

\`build-perl-binaries.yml\` gets \`apt-get install -y patchelf\` on the
Linux matrix so the next workflow_dispatch rebuild produces relocatable
binaries automatically.

## Test coverage

- \`TestComputeRelativeCoreDir\` — unit: fabricate an install tree, check
  the computed relative path to CORE.
- \`TestComputeRelativeCoreDir_NoLibperl\` — negative case.
- \`TestMakeRelocatable_EndToEnd\` — compiles a real ELF binary + shared
  lib with a deliberately-bad hardcoded RPATH, runs makeRelocatable,
  verifies the binary runs, then MOVES the whole install tree to a
  different directory and verifies it still runs (proving the fix is
  genuinely relocatable).

## Test plan

- [x] \`go test ./internal/perl/\` passes on Linux with patchelf installed.
- [x] End-to-end test proves a moved install tree still executes.
- [ ] After merge: workflow_dispatch \`build-perl-binaries.yml\` to produce
  new relocatable tarballs for the next binary release.

## Scope deliberately excluded

- Existing released binaries (rc70 and earlier) stay broken — users
  should build locally or wait for the next binary rebuild.
- macOS \`@loader_path\` equivalent: tracked as future work.
- Windows: no dynamic-library-path issue of this shape; not applicable.