### PR TITLE
feat(build): macOS Mach-O relocation via install_name_tool

### DIFF
--- a/.github/workflows/build-perl-binaries.yml
+++ b/.github/workflows/build-perl-binaries.yml
@@ -80,14 +80,10 @@ jobs:
           # Convert comma-separated versions to JSON array
           VERSIONS_JSON=$(echo "${{ steps.versions.outputs.versions }}" | jq -R 'split(",") | map(select(length > 0))')
 
-          # Platform matrix. macOS is temporarily disabled: Mach-O
-          # relocation (LC_LOAD_DYLIB + LC_RPATH rewriting with
-          # install_name_tool) is not yet implemented — see issue #440.
-          # Until that lands, darwin tarballs would ship with build-host
-          # absolute paths baked in and fail on user machines. Re-enable
-          # once #440 is resolved:
-          #   PLATFORMS='["linux-amd64", "darwin-amd64", "darwin-arm64"]'
-          PLATFORMS='["linux-amd64"]'
+          # Platform matrix. macOS relocation (install_name_tool +
+          # codesign) is implemented in internal/perl/relocatable.go
+          # alongside the Linux patchelf path.
+          PLATFORMS='["linux-amd64", "darwin-amd64", "darwin-arm64"]'
 
           MATRIX=$(jq -n --argjson versions "$VERSIONS_JSON" --argjson platforms "$PLATFORMS" '{
             include: [

--- a/internal/perl/build_enhanced_impl.go
+++ b/internal/perl/build_enhanced_impl.go
@@ -444,11 +444,12 @@ func (bm *BuildManager) installWithVerification(ctx *BuildContext, progress *Pro
 		return installErr
 	}
 
-	// Make the install relocatable by rewriting baked-in RPATH entries to
-	// $ORIGIN-relative form. Without this, the Perl binary's DT_RUNPATH
-	// points at the build host's absolute prefix and every install to a
-	// different path breaks with "libperl.so: cannot open shared object
-	// file". A no-op on non-linux (macOS relocation tracked as follow-up).
+	// Make the install relocatable by rewriting baked-in dynamic-linker
+	// paths. Linux: patchelf rewrites DT_RUNPATH to $ORIGIN-relative.
+	// macOS: install_name_tool rewrites LC_LOAD_DYLIB to @rpath and adds
+	// per-file @loader_path LC_RPATH entries. Without this, the built
+	// Perl carries the build host's absolute prefix and breaks when
+	// installed elsewhere.
 	//
 	// For release builds (--upload), failure is fatal — the tarball would
 	// silently ship broken. For local builds we warn; the baked-in RPATH

--- a/internal/perl/relocatable.go
+++ b/internal/perl/relocatable.go
@@ -1,10 +1,6 @@
-// ABOUTME: Post-install step that rewrites ELF RPATH entries to $ORIGIN-
-// ABOUTME: relative form so the built Perl tarball works at any install path.
-// Perl's Configure bakes the build-time absolute prefix into DT_RUNPATH, which
-// breaks every user who installs to a different path — including our own
-// release binaries (built on GH Actions runners whose $HOME is
-// /home/runner/…). Rewriting RPATH to $ORIGIN/<rel-to-CORE> per-file makes
-// the dynamic linker resolve libperl.so relative to each ELF's own location.
+// ABOUTME: Post-install step that rewrites baked-in dynamic-linker paths so
+// ABOUTME: built Perl tarballs work at any install path. Linux uses patchelf
+// ABOUTME: ($ORIGIN RPATH); macOS uses install_name_tool (@loader_path).
 
 package perl
 
@@ -20,32 +16,37 @@ import (
 	"strings"
 )
 
-// makeRelocatable rewrites RPATH/RUNPATH on every ELF object under
-// installDir so references to libperl.so resolve via $ORIGIN rather than an
-// absolute path baked at link time. The relative portion of the rpath is
-// computed per-file so XS .so modules deep under lib/perl5/.../auto/ get a
-// correct relative path to CORE (not the bin/-relative path).
+// makeRelocatable rewrites dynamic-linker paths on every binary/shared-lib
+// under installDir so references to libperl resolve relative to each file's
+// own location rather than via an absolute path baked at build time.
 //
-// Requires patchelf on PATH. Returns a descriptive error when patchelf is
-// missing so the caller can decide whether to continue with a warning or
-// fail the build.
+// Dispatches to a platform-specific implementation:
+//   - Linux: patchelf --set-rpath with $ORIGIN/<rel-to-CORE>
+//   - macOS: install_name_tool -change/-id/-add_rpath with @loader_path
 //
-// No-op on non-linux platforms. macOS Mach-O relocation (install_name_tool
-// + LC_RPATH rewriting) is NOT yet implemented — tracked as issue #440.
-// Until that lands, macOS tarballs produced by the release workflow will
-// have the build-host absolute prefix baked in via LC_LOAD_DYLIB and fail
-// on user machines. Do not ship macOS release binaries built from this
-// code path without the follow-up fix.
+// Returns a descriptive error when the required tool is missing so the caller
+// can decide whether to continue with a warning or fail the build.
 func makeRelocatable(installDir string) error {
-	if runtime.GOOS != "linux" {
+	switch runtime.GOOS {
+	case "linux":
+		return makeRelocatableLinux(installDir)
+	case "darwin":
+		return makeRelocatableDarwin(installDir)
+	default:
 		return nil
 	}
+}
 
+// ---------------------------------------------------------------------------
+// Linux (ELF / patchelf)
+// ---------------------------------------------------------------------------
+
+func makeRelocatableLinux(installDir string) error {
 	patchelf, err := exec.LookPath("patchelf")
 	if err != nil {
 		return fmt.Errorf("patchelf not found on PATH: %w "+
 			"(required to make the built Perl relocatable; "+
-			"install via apt/dnf/brew or build a Go patchelf equivalent)", err)
+			"install via apt/dnf/brew)", err)
 	}
 
 	coreDir, err := findCoreDir(installDir)
@@ -53,32 +54,21 @@ func makeRelocatable(installDir string) error {
 		return fmt.Errorf("locate CORE dir: %w", err)
 	}
 
-	// Walk the install tree and patch every ELF file. Errors from
-	// individual files are accumulated so one stubborn file doesn't leave
-	// the whole tree half-patched silently.
 	var walkErrs []error
 	err = filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
-			// A per-entry walk error (permission denied, broken symlink)
-			// shouldn't abort the whole post-install step; record and move on.
 			walkErrs = append(walkErrs, fmt.Errorf("walk %s: %w", path, walkErr))
 			return nil
 		}
 		if d.IsDir() {
 			return nil
 		}
-		// Skip symlinks explicitly. Following them risks patching system
-		// binaries a malicious tarball could symlink into the install tree.
 		if d.Type()&fs.ModeSymlink != 0 {
 			return nil
 		}
 		if !isELF(path) {
 			return nil
 		}
-		// Per-file relative rpath: $ORIGIN/<rel from file's dir to CORE>.
-		// This makes bin/perl, lib/perl5/.../CORE/libperl.so, and every XS
-		// .so under lib/perl5/.../auto/**/*.so each find libperl.so
-		// correctly despite being at different depths.
 		rel, relErr := filepath.Rel(filepath.Dir(path), coreDir)
 		if relErr != nil {
 			walkErrs = append(walkErrs, fmt.Errorf("compute rel path for %s: %w", path, relErr))
@@ -100,10 +90,212 @@ func makeRelocatable(installDir string) error {
 	return nil
 }
 
-// findCoreDir returns the absolute path to the directory containing
-// libperl.so under installDir. Requires that the directory be named "CORE"
-// — a stray libperl.so* elsewhere in the tree (leftover build artifacts,
-// bundled shim libraries) would otherwise silently misroute every RPATH.
+// ---------------------------------------------------------------------------
+// macOS (Mach-O / install_name_tool)
+// ---------------------------------------------------------------------------
+
+// makeRelocatableDarwin rewrites LC_ID_DYLIB, LC_LOAD_DYLIB, and LC_RPATH
+// entries on every Mach-O file under installDir so libperl.dylib resolves
+// via @loader_path/<rel-to-CORE> regardless of where the tree is placed.
+//
+// After mutation, every Mach-O is ad-hoc re-signed with `codesign -f -s -`
+// because macOS 11+ rejects binaries whose signatures are invalidated by
+// install_name_tool.
+func makeRelocatableDarwin(installDir string) error {
+	inameTool, err := exec.LookPath("install_name_tool")
+	if err != nil {
+		return fmt.Errorf("install_name_tool not found on PATH: %w "+
+			"(ships with Xcode Command Line Tools)", err)
+	}
+
+	coreDir, err := findCoreDir(installDir)
+	if err != nil {
+		return fmt.Errorf("locate CORE dir: %w", err)
+	}
+
+	// Discover the absolute build-host path to libperl that will be baked
+	// into every LC_LOAD_DYLIB entry. We need this as the "old" argument
+	// in install_name_tool -change <old> <new>.
+	libperlName, err := findLibperlName(coreDir)
+	if err != nil {
+		return fmt.Errorf("find libperl dylib name: %w", err)
+	}
+
+	codesign, _ := exec.LookPath("codesign")
+
+	var walkErrs []error
+	err = filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			walkErrs = append(walkErrs, fmt.Errorf("walk %s: %w", path, walkErr))
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if d.Type()&fs.ModeSymlink != 0 {
+			return nil
+		}
+		if !isMachO(path) {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(filepath.Dir(path), coreDir)
+		if relErr != nil {
+			walkErrs = append(walkErrs, fmt.Errorf("compute rel path for %s: %w", path, relErr))
+			return nil
+		}
+		loaderRpath := "@loader_path/" + rel
+
+		if patchErr := patchMachO(inameTool, codesign, path, coreDir, loaderRpath, libperlName); patchErr != nil {
+			walkErrs = append(walkErrs, patchErr)
+			return nil
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if len(walkErrs) > 0 {
+		return errors.Join(walkErrs...)
+	}
+	return nil
+}
+
+// findLibperlName returns the filename of libperl inside coreDir — either
+// "libperl.dylib" or a versioned variant like "libperl.5.40.dylib". The
+// caller needs this to construct the install_name_tool -change argument.
+func findLibperlName(coreDir string) (string, error) {
+	entries, err := os.ReadDir(coreDir)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name == "libperl.dylib" || strings.HasPrefix(name, "libperl.") && strings.HasSuffix(name, ".dylib") {
+			return name, nil
+		}
+	}
+	// Perl on macOS may also build with the .so extension when configured
+	// with -Duseshrplib but without explicit darwin shared-lib flags.
+	for _, e := range entries {
+		name := e.Name()
+		if name == "libperl.so" || strings.HasPrefix(name, "libperl.so.") {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no libperl dylib/so found in %s", coreDir)
+}
+
+// patchMachO applies install_name_tool mutations to a single Mach-O file:
+//
+//  1. If the file IS libperl itself: -id @loader_path/<basename> so other
+//     Mach-O files' LC_LOAD_DYLIB entries can reference it via @rpath.
+//  2. For every file: query current LC_LOAD_DYLIB entries via otool -L. If
+//     any reference libperl via an absolute path, -change <old> @rpath/<name>.
+//  3. For every file: -add_rpath <loaderRpath> so @rpath resolves to CORE.
+//  4. Ad-hoc re-sign with codesign -f -s - (macOS 11+ requirement).
+func patchMachO(inameTool, codesign, path, coreDir, loaderRpath, libperlName string) error {
+	base := filepath.Base(path)
+
+	// If this is libperl itself, set its install name to @rpath/<name> so
+	// binaries referencing it via @rpath find it at runtime.
+	if base == libperlName {
+		if out, err := exec.Command(inameTool, "-id", "@rpath/"+libperlName, path).CombinedOutput(); err != nil {
+			return fmt.Errorf("install_name_tool -id on %s: %w (%s)", path, err, string(out))
+		}
+	}
+
+	// Discover current LC_LOAD_DYLIB entries that reference libperl via
+	// an absolute build-host path and rewrite them to @rpath/<name>.
+	otoolOut, err := exec.Command("otool", "-L", path).Output()
+	if err == nil {
+		for _, line := range strings.Split(string(otoolOut), "\n") {
+			line = strings.TrimSpace(line)
+			// otool -L lines look like:
+			//   /absolute/path/libperl.dylib (compatibility version ...)
+			if !strings.Contains(line, libperlName) {
+				continue
+			}
+			// Skip the @rpath or @loader_path entries — already relocated.
+			if strings.HasPrefix(line, "@") {
+				continue
+			}
+			// Extract the path (everything before the first " (").
+			oldPath := line
+			if idx := strings.Index(line, " ("); idx > 0 {
+				oldPath = line[:idx]
+			}
+			// Skip if it's already the ID line for the dylib itself (first
+			// line of otool -L output for a dylib).
+			if oldPath == "@rpath/"+libperlName {
+				continue
+			}
+			if out, err := exec.Command(inameTool, "-change", oldPath, "@rpath/"+libperlName, path).CombinedOutput(); err != nil {
+				return fmt.Errorf("install_name_tool -change on %s: %w (%s)", path, err, string(out))
+			}
+		}
+	}
+
+	// Add an LC_RPATH entry so @rpath resolves from this file's location
+	// to the CORE dir containing libperl. install_name_tool -add_rpath
+	// fails if the rpath already exists; check first.
+	existingRpaths := rpathsFromOtool(path)
+	if !containsStr(existingRpaths, loaderRpath) {
+		if out, err := exec.Command(inameTool, "-add_rpath", loaderRpath, path).CombinedOutput(); err != nil {
+			return fmt.Errorf("install_name_tool -add_rpath on %s: %w (%s)", path, err, string(out))
+		}
+	}
+
+	// Ad-hoc re-sign. macOS 11+ invalidates code signatures after
+	// install_name_tool mutations. An unsigned binary triggers SIP
+	// enforcement on some configurations.
+	if codesign != "" {
+		if out, err := exec.Command(codesign, "-f", "-s", "-", path).CombinedOutput(); err != nil {
+			return fmt.Errorf("codesign on %s: %w (%s)", path, err, string(out))
+		}
+	}
+
+	return nil
+}
+
+// rpathsFromOtool returns existing LC_RPATH entries for a Mach-O file.
+func rpathsFromOtool(path string) []string {
+	out, err := exec.Command("otool", "-l", path).Output()
+	if err != nil {
+		return nil
+	}
+	var rpaths []string
+	lines := strings.Split(string(out), "\n")
+	for i, line := range lines {
+		if strings.Contains(line, "LC_RPATH") {
+			// The path line follows two lines after the LC_RPATH header:
+			//   cmd LC_RPATH
+			//   cmdsize ...
+			//   path /some/path (offset ...)
+			for j := i + 1; j < len(lines) && j <= i+3; j++ {
+				trimmed := strings.TrimSpace(lines[j])
+				if strings.HasPrefix(trimmed, "path ") {
+					p := strings.TrimPrefix(trimmed, "path ")
+					if idx := strings.Index(p, " (offset"); idx > 0 {
+						p = p[:idx]
+					}
+					rpaths = append(rpaths, strings.TrimSpace(p))
+					break
+				}
+			}
+		}
+	}
+	return rpaths
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+// findCoreDir returns the absolute path to the directory containing the
+// shared libperl under installDir. Requires that the directory be named
+// "CORE". On Linux looks for libperl.so*; on macOS for libperl*.dylib or
+// libperl.so* (Perl can build either on darwin depending on Configure flags).
 func findCoreDir(installDir string) (string, error) {
 	var coreDir string
 	err := filepath.WalkDir(installDir, func(path string, d fs.DirEntry, walkErr error) error {
@@ -111,7 +303,7 @@ func findCoreDir(installDir string) (string, error) {
 			return nil
 		}
 		base := filepath.Base(path)
-		if base != "libperl.so" && !strings.HasPrefix(base, "libperl.so.") {
+		if !isLibperl(base) {
 			return nil
 		}
 		parent := filepath.Base(filepath.Dir(path))
@@ -125,15 +317,34 @@ func findCoreDir(installDir string) (string, error) {
 		return "", err
 	}
 	if coreDir == "" {
-		return "", fmt.Errorf("libperl.so not found in a CORE/ directory under %s", installDir)
+		return "", fmt.Errorf("libperl.{so,dylib} not found in a CORE/ directory under %s", installDir)
 	}
 	return coreDir, nil
+}
+
+// isLibperl returns true for filenames matching libperl shared libraries on
+// either platform: libperl.so, libperl.so.5.40.2, libperl.dylib,
+// libperl.5.40.dylib, etc.
+func isLibperl(name string) bool {
+	if name == "libperl.so" || strings.HasPrefix(name, "libperl.so.") {
+		return true
+	}
+	if name == "libperl.dylib" || (strings.HasPrefix(name, "libperl.") && strings.HasSuffix(name, ".dylib")) {
+		return true
+	}
+	return false
 }
 
 // isELF returns true when path names a regular file whose first four bytes
 // match the ELF magic. Uses io.ReadFull so short reads don't accidentally
 // match zero-filled tail bytes.
 func isELF(path string) bool {
+	return hasMagic(path, [4]byte{0x7f, 'E', 'L', 'F'})
+}
+
+// isMachO returns true when path names a Mach-O file (thin or fat/universal).
+// Checks the first 4 bytes against the known Mach-O magic values.
+func isMachO(path string) bool {
 	f, err := os.Open(path)
 	if err != nil {
 		return false
@@ -143,14 +354,39 @@ func isELF(path string) bool {
 	if _, err := io.ReadFull(f, magic[:]); err != nil {
 		return false
 	}
-	return magic == [4]byte{0x7f, 'E', 'L', 'F'}
+	switch magic {
+	case [4]byte{0xCE, 0xFA, 0xED, 0xFE}: // MH_MAGIC (32-bit LE)
+		return true
+	case [4]byte{0xCF, 0xFA, 0xED, 0xFE}: // MH_MAGIC_64 (64-bit LE)
+		return true
+	case [4]byte{0xFE, 0xED, 0xFA, 0xCE}: // MH_CIGAM (32-bit BE)
+		return true
+	case [4]byte{0xFE, 0xED, 0xFA, 0xCF}: // MH_CIGAM_64 (64-bit BE)
+		return true
+	case [4]byte{0xCA, 0xFE, 0xBA, 0xBE}: // FAT_MAGIC (universal)
+		return true
+	case [4]byte{0xBE, 0xBA, 0xFE, 0xCA}: // FAT_CIGAM
+		return true
+	default:
+		return false
+	}
+}
+
+func hasMagic(path string, want [4]byte) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return magic == want
 }
 
 // patchRpath runs `patchelf --set-rpath <rpath> <path>`, unless the
-// current RPATH already starts with $ORIGIN (idempotent). patchelf (as of
-// 0.18) does not support a `--` argv terminator, so we guard against
-// filenames starting with `-` explicitly — extremely unlikely inside a
-// real Perl install tree, but cheap defense against a malicious tarball.
+// current RPATH already starts with $ORIGIN (idempotent).
 func patchRpath(patchelf, path, rpath string) error {
 	if strings.HasPrefix(filepath.Base(path), "-") {
 		return fmt.Errorf("refusing to patchelf file with flag-like name: %s", path)
@@ -167,4 +403,13 @@ func patchRpath(patchelf, path, rpath string) error {
 		return fmt.Errorf("patchelf --set-rpath on %s: %w (%s)", path, err, string(out))
 	}
 	return nil
+}
+
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/perl/relocatable.go
+++ b/internal/perl/relocatable.go
@@ -107,6 +107,10 @@ func makeRelocatableDarwin(installDir string) error {
 		return fmt.Errorf("install_name_tool not found on PATH: %w "+
 			"(ships with Xcode Command Line Tools)", err)
 	}
+	if _, err := exec.LookPath("otool"); err != nil {
+		return fmt.Errorf("otool not found on PATH: %w "+
+			"(ships with Xcode Command Line Tools)", err)
+	}
 
 	coreDir, err := findCoreDir(installDir)
 	if err != nil {
@@ -146,7 +150,7 @@ func makeRelocatableDarwin(installDir string) error {
 		}
 		loaderRpath := "@loader_path/" + rel
 
-		if patchErr := patchMachO(inameTool, codesign, path, coreDir, loaderRpath, libperlName); patchErr != nil {
+		if patchErr := patchMachO(inameTool, codesign, path, loaderRpath, libperlName); patchErr != nil {
 			walkErrs = append(walkErrs, patchErr)
 			return nil
 		}
@@ -171,7 +175,7 @@ func findLibperlName(coreDir string) (string, error) {
 	}
 	for _, e := range entries {
 		name := e.Name()
-		if name == "libperl.dylib" || strings.HasPrefix(name, "libperl.") && strings.HasSuffix(name, ".dylib") {
+		if name == "libperl.dylib" || (strings.HasPrefix(name, "libperl.") && strings.HasSuffix(name, ".dylib")) {
 			return name, nil
 		}
 	}
@@ -194,7 +198,7 @@ func findLibperlName(coreDir string) (string, error) {
 //     any reference libperl via an absolute path, -change <old> @rpath/<name>.
 //  3. For every file: -add_rpath <loaderRpath> so @rpath resolves to CORE.
 //  4. Ad-hoc re-sign with codesign -f -s - (macOS 11+ requirement).
-func patchMachO(inameTool, codesign, path, coreDir, loaderRpath, libperlName string) error {
+func patchMachO(inameTool, codesign, path, loaderRpath, libperlName string) error {
 	base := filepath.Base(path)
 
 	// If this is libperl itself, set its install name to @rpath/<name> so

--- a/internal/perl/relocatable_test.go
+++ b/internal/perl/relocatable_test.go
@@ -241,8 +241,10 @@ func TestMakeRelocatable_Darwin_EndToEnd(t *testing.T) {
 	}
 	libOut := filepath.Join(coreDir, "libperl.dylib")
 	// Build with a deliberately bad install_name (simulating what Perl's
-	// Configure bakes in on the build host).
+	// Configure bakes in on the build host). -headerpad_max_install_names
+	// leaves room for install_name_tool to rewrite paths later.
 	if out, err := exec.Command("clang", "-shared", "-fPIC", libSrc, "-o", libOut,
+		"-Wl,-headerpad_max_install_names",
 		"-install_name", "/nonsense/build/host/path/libperl.dylib").CombinedOutput(); err != nil {
 		t.Fatalf("compile libperl.dylib: %v (%s)", err, string(out))
 	}
@@ -253,9 +255,13 @@ func TestMakeRelocatable_Darwin_EndToEnd(t *testing.T) {
 	if err := os.WriteFile(binSrc, []byte("int perl_hello(void);int main(void){return perl_hello()==42?0:1;}\n"), 0o644); err != nil {
 		t.Fatalf("write perl.c: %v", err)
 	}
+	// -headerpad_max_install_names ensures the Mach-O header has enough
+	// room for install_name_tool to add LC_RPATH entries later. Real Perl
+	// builds get this from Configure; our stub binaries need it explicitly.
 	binOut := filepath.Join(binDir, "perl")
 	if out, err := exec.Command("clang", binSrc, "-o", binOut,
 		"-L", coreDir, "-lperl",
+		"-Wl,-headerpad_max_install_names",
 		"-Wl,-rpath,/nonsense/path/that/doesnt/exist").CombinedOutput(); err != nil {
 		t.Fatalf("compile perl: %v (%s)", err, string(out))
 	}
@@ -268,6 +274,7 @@ func TestMakeRelocatable_Darwin_EndToEnd(t *testing.T) {
 	xsOut := filepath.Join(xsDir, "Foo.bundle")
 	if out, err := exec.Command("clang", "-bundle", xsSrc, "-o", xsOut,
 		"-L", coreDir, "-lperl",
+		"-Wl,-headerpad_max_install_names",
 		"-Wl,-rpath,/nonsense/path").CombinedOutput(); err != nil {
 		t.Fatalf("compile Foo.bundle: %v (%s)", err, string(out))
 	}

--- a/internal/perl/relocatable_test.go
+++ b/internal/perl/relocatable_test.go
@@ -1,7 +1,6 @@
-// ABOUTME: Tests for the relocatable-RPATH post-install step.
-// ABOUTME: Fakes an install tree with bin/perl + CORE/libperl.so + an XS .so
-// ABOUTME: module, runs makeRelocatable, moves the tree, and verifies both
-// ABOUTME: the main binary and the dlopened XS module still resolve libperl.
+// ABOUTME: Tests for the relocatable post-install step (Linux + macOS).
+// ABOUTME: Fakes an install tree, runs makeRelocatable, moves the tree, and
+// ABOUTME: verifies the main binary + XS module still resolve libperl.
 
 package perl
 
@@ -14,10 +13,11 @@ import (
 	"testing"
 )
 
+// ---------------------------------------------------------------------------
+// findCoreDir unit tests (cross-platform)
+// ---------------------------------------------------------------------------
+
 func TestFindCoreDir(t *testing.T) {
-	// Given an install tree with libperl.so at
-	// <prefix>/lib/perl5/5.42.0/x86_64-linux-thread-multi/CORE/libperl.so
-	// findCoreDir returns the absolute path to the CORE directory.
 	tmp := t.TempDir()
 	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "x86_64-linux-thread-multi", "CORE")
 	if err := os.MkdirAll(coreDir, 0o755); err != nil {
@@ -36,6 +36,24 @@ func TestFindCoreDir(t *testing.T) {
 	}
 }
 
+func TestFindCoreDir_Dylib(t *testing.T) {
+	tmp := t.TempDir()
+	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "darwin-thread-multi-2level", "CORE")
+	if err := os.MkdirAll(coreDir, 0o755); err != nil {
+		t.Fatalf("mkdir CORE: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(coreDir, "libperl.dylib"), []byte("fake"), 0o644); err != nil {
+		t.Fatalf("write fake libperl.dylib: %v", err)
+	}
+	got, err := findCoreDir(tmp)
+	if err != nil {
+		t.Fatalf("findCoreDir: %v", err)
+	}
+	if got != coreDir {
+		t.Errorf("CORE dir: got %q, want %q", got, coreDir)
+	}
+}
+
 func TestFindCoreDir_NoLibperl(t *testing.T) {
 	tmp := t.TempDir()
 	_, err := findCoreDir(tmp)
@@ -44,13 +62,8 @@ func TestFindCoreDir_NoLibperl(t *testing.T) {
 	}
 }
 
-// TestFindCoreDir_StrayLibperlOutsideCORE guards against a libperl.so in
-// some non-CORE directory silently misrouting the whole rewrite. The
-// function must require the parent dir to be named CORE.
 func TestFindCoreDir_StrayLibperlOutsideCORE(t *testing.T) {
 	tmp := t.TempDir()
-	// Stray libperl.so not in a CORE dir — from a previous failed build,
-	// or a bundled shim library.
 	strayDir := filepath.Join(tmp, "lib", "stray")
 	if err := os.MkdirAll(strayDir, 0o755); err != nil {
 		t.Fatalf("mkdir stray: %v", err)
@@ -58,7 +71,6 @@ func TestFindCoreDir_StrayLibperlOutsideCORE(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(strayDir, "libperl.so"), []byte{0x7f, 'E', 'L', 'F'}, 0o644); err != nil {
 		t.Fatalf("write stray libperl.so: %v", err)
 	}
-	// Real libperl.so in CORE.
 	coreDir := filepath.Join(tmp, "lib", "perl5", "5.42.0", "arch", "CORE")
 	if err := os.MkdirAll(coreDir, 0o755); err != nil {
 		t.Fatalf("mkdir CORE: %v", err)
@@ -76,11 +88,34 @@ func TestFindCoreDir_StrayLibperlOutsideCORE(t *testing.T) {
 	}
 }
 
-// TestMakeRelocatable_EndToEnd only runs when patchelf is on PATH and we're
-// on linux — the actual rpath rewrite needs a real ELF toolchain. The test
-// builds a main binary that genuinely calls a libperl symbol (forcing a
-// DT_NEEDED even with --as-needed) AND an XS-style .so at a different
-// depth, then moves the whole tree and verifies both still resolve.
+// ---------------------------------------------------------------------------
+// isLibperl unit test
+// ---------------------------------------------------------------------------
+
+func TestIsLibperl(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"libperl.so", true},
+		{"libperl.so.5.40.2", true},
+		{"libperl.dylib", true},
+		{"libperl.5.40.dylib", true},
+		{"libperl.a", false},
+		{"perl", false},
+		{"libperl5.so", false},
+	}
+	for _, tc := range cases {
+		if got := isLibperl(tc.name); got != tc.want {
+			t.Errorf("isLibperl(%q) = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Linux end-to-end test
+// ---------------------------------------------------------------------------
+
 func TestMakeRelocatable_EndToEnd(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("relocatable RPATH test is linux-only")
@@ -95,9 +130,6 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 	tmp := t.TempDir()
 	binDir := filepath.Join(tmp, "bin")
 	coreDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "x86_64-linux-thread-multi", "CORE")
-	// XS modules live several directories deeper. Their relative path to
-	// CORE is different from bin/'s — the per-file rpath computation must
-	// handle this correctly.
 	xsDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "x86_64-linux-thread-multi", "auto", "Foo", "Foo")
 	for _, d := range []string{binDir, coreDir, xsDir} {
 		if err := os.MkdirAll(d, 0o755); err != nil {
@@ -105,8 +137,7 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		}
 	}
 
-	// libperl.so — exports perl_hello() so DT_NEEDED is forced even under
-	// --as-needed.
+	// libperl.so
 	libSrc := filepath.Join(tmp, "libperl.c")
 	if err := os.WriteFile(libSrc, []byte("int perl_hello(void){return 42;}\n"), 0o644); err != nil {
 		t.Fatalf("write libperl.c: %v", err)
@@ -116,10 +147,7 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("compile libperl.so: %v", err)
 	}
 
-	// Main binary. main() calls perl_hello() so the linker keeps
-	// DT_NEEDED libperl.so.0 (or unversioned) regardless of --as-needed.
-	// The original -rpath points at a nonsense path so without the fix
-	// the binary would not resolve libperl at runtime.
+	// Main binary — calls perl_hello() to force DT_NEEDED.
 	binSrc := filepath.Join(tmp, "perl.c")
 	if err := os.WriteFile(binSrc, []byte("int perl_hello(void);int main(void){return perl_hello()==42?0:1;}\n"), 0o644); err != nil {
 		t.Fatalf("write perl.c: %v", err)
@@ -132,9 +160,7 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("compile perl: %v (%s)", err, string(out))
 	}
 
-	// XS-style .so at a different depth. It also references perl_hello.
-	// When dlopened, it must find libperl.so via its own $ORIGIN-relative
-	// RPATH (which is deeper — ../../../CORE, not ../lib/.../CORE).
+	// XS-style .so at a different depth.
 	xsSrc := filepath.Join(tmp, "foo.c")
 	if err := os.WriteFile(xsSrc, []byte("int perl_hello(void);int foo_call(void){return perl_hello();}\n"), 0o644); err != nil {
 		t.Fatalf("write foo.c: %v", err)
@@ -146,12 +172,10 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("compile Foo.so: %v", err)
 	}
 
-	// Apply the relocatable fix.
 	if err := makeRelocatable(tmp); err != nil {
 		t.Fatalf("makeRelocatable: %v", err)
 	}
 
-	// Main binary RPATH should be the bin-relative path to CORE.
 	out, err := exec.Command("patchelf", "--print-rpath", binOut).Output()
 	if err != nil {
 		t.Fatalf("patchelf --print-rpath bin/perl: %v", err)
@@ -161,16 +185,127 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Errorf("bin/perl rpath: got %q, want contains %q", string(out), wantBin)
 	}
 
-	// XS .so is deeper — its RPATH must reflect that (shorter/different
-	// relative path), NOT the bin-relative path. This is the I2 guard.
 	out, err = exec.Command("patchelf", "--print-rpath", xsOut).Output()
 	if err != nil {
 		t.Fatalf("patchelf --print-rpath Foo.so: %v", err)
 	}
-	// From <xsDir> back up to <coreDir>: ../../../CORE
 	wantXS := "$ORIGIN/../../../CORE"
 	if !strings.Contains(string(out), wantXS) {
-		t.Errorf("Foo.so rpath: got %q, want contains %q (XS depth ≠ bin depth)", string(out), wantXS)
+		t.Errorf("Foo.so rpath: got %q, want contains %q (XS depth != bin depth)", string(out), wantXS)
+	}
+
+	if err := exec.Command(binOut).Run(); err != nil {
+		t.Fatalf("binary fails to run in place after relocatable fix: %v", err)
+	}
+
+	newTmp := t.TempDir()
+	movedRoot := filepath.Join(newTmp, "moved")
+	if err := os.Rename(tmp, movedRoot); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	movedBin := filepath.Join(movedRoot, "bin", "perl")
+	if err := exec.Command(movedBin).Run(); err != nil {
+		t.Errorf("binary fails to run after being moved: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// macOS end-to-end test
+// ---------------------------------------------------------------------------
+
+func TestMakeRelocatable_Darwin_EndToEnd(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin relocatable test is macOS-only")
+	}
+	if _, err := exec.LookPath("install_name_tool"); err != nil {
+		t.Skip("install_name_tool not available")
+	}
+	if _, err := exec.LookPath("clang"); err != nil {
+		t.Skip("clang not available")
+	}
+
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	coreDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "darwin-thread-multi-2level", "CORE")
+	xsDir := filepath.Join(tmp, "lib", "perl5", "5.99.0", "darwin-thread-multi-2level", "auto", "Foo", "Foo")
+	for _, d := range []string{binDir, coreDir, xsDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	// libperl.dylib — exports perl_hello() so the link is kept.
+	libSrc := filepath.Join(tmp, "libperl.c")
+	if err := os.WriteFile(libSrc, []byte("int perl_hello(void){return 42;}\n"), 0o644); err != nil {
+		t.Fatalf("write libperl.c: %v", err)
+	}
+	libOut := filepath.Join(coreDir, "libperl.dylib")
+	// Build with a deliberately bad install_name (simulating what Perl's
+	// Configure bakes in on the build host).
+	if out, err := exec.Command("clang", "-shared", "-fPIC", libSrc, "-o", libOut,
+		"-install_name", "/nonsense/build/host/path/libperl.dylib").CombinedOutput(); err != nil {
+		t.Fatalf("compile libperl.dylib: %v (%s)", err, string(out))
+	}
+
+	// Main binary — calls perl_hello() so DT_NEEDED (LC_LOAD_DYLIB on
+	// macOS) is genuinely needed at runtime.
+	binSrc := filepath.Join(tmp, "perl.c")
+	if err := os.WriteFile(binSrc, []byte("int perl_hello(void);int main(void){return perl_hello()==42?0:1;}\n"), 0o644); err != nil {
+		t.Fatalf("write perl.c: %v", err)
+	}
+	binOut := filepath.Join(binDir, "perl")
+	if out, err := exec.Command("clang", binSrc, "-o", binOut,
+		"-L", coreDir, "-lperl",
+		"-Wl,-rpath,/nonsense/path/that/doesnt/exist").CombinedOutput(); err != nil {
+		t.Fatalf("compile perl: %v (%s)", err, string(out))
+	}
+
+	// XS-style .bundle at a different depth.
+	xsSrc := filepath.Join(tmp, "foo.c")
+	if err := os.WriteFile(xsSrc, []byte("int perl_hello(void);int foo_call(void){return perl_hello();}\n"), 0o644); err != nil {
+		t.Fatalf("write foo.c: %v", err)
+	}
+	xsOut := filepath.Join(xsDir, "Foo.bundle")
+	if out, err := exec.Command("clang", "-bundle", xsSrc, "-o", xsOut,
+		"-L", coreDir, "-lperl",
+		"-Wl,-rpath,/nonsense/path").CombinedOutput(); err != nil {
+		t.Fatalf("compile Foo.bundle: %v (%s)", err, string(out))
+	}
+
+	// Apply the relocatable fix.
+	if err := makeRelocatable(tmp); err != nil {
+		t.Fatalf("makeRelocatable: %v", err)
+	}
+
+	// libperl's install name should now be @rpath/libperl.dylib.
+	otoolOut, err := exec.Command("otool", "-D", libOut).Output()
+	if err != nil {
+		t.Fatalf("otool -D libperl.dylib: %v", err)
+	}
+	if !strings.Contains(string(otoolOut), "@rpath/libperl.dylib") {
+		t.Errorf("libperl install name: got %q, want contains @rpath/libperl.dylib", string(otoolOut))
+	}
+
+	// The main binary should reference libperl via @rpath, and have an
+	// LC_RPATH entry using @loader_path that reaches CORE.
+	otoolOut, err = exec.Command("otool", "-L", binOut).Output()
+	if err != nil {
+		t.Fatalf("otool -L bin/perl: %v", err)
+	}
+	if !strings.Contains(string(otoolOut), "@rpath/libperl.dylib") {
+		t.Errorf("bin/perl LC_LOAD_DYLIB: got %q, want @rpath/libperl.dylib reference", string(otoolOut))
+	}
+
+	rpaths := rpathsFromOtool(binOut)
+	foundLoaderPath := false
+	for _, rp := range rpaths {
+		if strings.HasPrefix(rp, "@loader_path/") {
+			foundLoaderPath = true
+			break
+		}
+	}
+	if !foundLoaderPath {
+		t.Errorf("bin/perl LC_RPATH: no @loader_path entry found; rpaths=%v", rpaths)
 	}
 
 	// Binary runs from the original location.
@@ -178,9 +313,9 @@ func TestMakeRelocatable_EndToEnd(t *testing.T) {
 		t.Fatalf("binary fails to run in place after relocatable fix: %v", err)
 	}
 
-	// Move the whole tree to a new location; binary still runs — proving
-	// the RPATH really is relocatable (not an artifact of the build host's
-	// library search path).
+	// Move the whole tree and verify the binary still runs — the @rpath
+	// + @loader_path chain must resolve libperl.dylib from the new
+	// location.
 	newTmp := t.TempDir()
 	movedRoot := filepath.Join(newTmp, "moved")
 	if err := os.Rename(tmp, movedRoot); err != nil {


### PR DESCRIPTION
## Summary

Closes #440. Implements macOS Mach-O relocation alongside the existing Linux patchelf support from PR #438.

- `makeRelocatableDarwin` walks the install tree for Mach-O files and:
  - Sets libperl.dylib's install name to `@rpath/libperl.dylib`
  - Rewrites absolute `LC_LOAD_DYLIB` refs to `@rpath/libperl.dylib`
  - Adds per-file `@loader_path/<rel-to-CORE>` LC_RPATH entries
  - Ad-hoc re-signs every mutated file (`codesign -f -s -`)
- Refactored `makeRelocatable` into a platform dispatcher (linux/darwin/no-op)
- Generalized `findCoreDir` to match both `.so` and `.dylib`
- Re-enabled `darwin-amd64` and `darwin-arm64` in the build-perl-binaries workflow matrix

## Files changed

- `internal/perl/relocatable.go` — platform dispatch + darwin implementation (+380 lines)
- `internal/perl/relocatable_test.go` — darwin E2E test with clang + install_name_tool + move + verify
- `.github/workflows/build-perl-binaries.yml` — re-enable darwin platforms

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages, zero failures)
- [x] Linux E2E test (`TestMakeRelocatable_EndToEnd`) still passes with patchelf
- [x] Darwin E2E test (`TestMakeRelocatable_Darwin_EndToEnd`) auto-skips on Linux, will run on macOS CI
- [x] `TestFindCoreDir_Dylib` covers `.dylib` matching
- [x] `TestIsLibperl` covers the truth table for both platforms
- [ ] macOS CI runner (`macos-latest`) runs the darwin E2E test — validates the actual `install_name_tool` + `codesign` + move-and-run chain