### PR TITLE
fix: updater chmod + progress bar scrolling

### DIFF
--- a/internal/archive/extractor.go
+++ b/internal/archive/extractor.go
@@ -181,18 +181,8 @@ func (e *BinaryExtractor) extractTarFile(reader io.Reader, targetPath string, mo
 		return fmt.Errorf("copying file content: %w", err)
 	}
 
-	// Set permissions. Mask to os.ModePerm so POSIX file-type bits in the
-	// tar header (e.g. S_IFREG 0100000) don't leak into the chmod call,
-	// and ensure the executable bit is set — a tar that shipped the
-	// binary with 0644 would otherwise leave us with a non-executable
-	// file and an obscure "not executable" failure downstream in the
-	// updater's validation step.
-	perm := os.FileMode(mode) & os.ModePerm
-	if perm&0111 == 0 {
-		perm |= 0755
-	}
-	if err := os.Chmod(targetPath, perm); err != nil {
-		return fmt.Errorf("setting file permissions: %w", err)
+	if err := applyExecutablePermissions(targetPath, os.FileMode(mode)); err != nil {
+		return err
 	}
 
 	return nil
@@ -224,18 +214,25 @@ func (e *BinaryExtractor) extractZipFile(file *zip.File, targetPath string) erro
 		return fmt.Errorf("copying file content: %w", err)
 	}
 
-	// Set permissions. ZIP mode bits are unreliable on cross-platform
-	// archives (Windows-authored zips often have mode 0 or 0644), so mask
-	// to os.ModePerm and force the executable bit — if the file is in the
-	// archive because we want to run it, we need +x regardless.
-	perm := file.FileInfo().Mode() & os.ModePerm
-	if perm&0111 == 0 {
-		perm |= 0755
+	if err := applyExecutablePermissions(targetPath, file.FileInfo().Mode()); err != nil {
+		return err
 	}
+
+	return nil
+}
+
+// applyExecutablePermissions sets the mode on an extracted file, masking
+// POSIX file-type bits (S_IFREG 0100000) out of tar header modes and ZIP
+// FileInfo().Mode() before passing to os.Chmod. The target binary's
+// executable bit is guaranteed separately by the updater's call to
+// platform.MakeExecutable in internal/updater/updater.go — doing it here
+// too would over-chmod every archive entry (man pages, completions) and
+// silently mark them executable.
+func applyExecutablePermissions(targetPath string, raw os.FileMode) error {
+	perm := raw & os.ModePerm
 	if err := os.Chmod(targetPath, perm); err != nil {
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
-
 	return nil
 }
 
@@ -279,15 +276,23 @@ func (e *BinaryExtractor) findMainExecutable(extractedFiles []string, platform s
 
 		fileName := filepath.Base(file)
 
-		// Check if this matches expected executable name
+		// Check if this matches an expected executable name. We match
+		// by name only — mode bits are unreliable on cross-platform
+		// tarballs (a packaging step occasionally strips +x). When a
+		// matching candidate is found without the exec bit, re-apply
+		// 0755 so downstream validation succeeds. This is scoped to the
+		// single binary we care about; other archive entries are left
+		// with whatever mode the archive specified.
 		for _, expected := range expectedNames {
-			if fileName == expected {
-				// Check if it's executable on Unix-like systems
-				if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
-					continue
-				}
-				candidates = append(candidates, file)
+			if fileName != expected {
+				continue
 			}
+			if runtime.GOOS != "windows" && info.Mode()&0111 == 0 {
+				if err := os.Chmod(file, 0755); err != nil {
+					return "", fmt.Errorf("setting executable bit on %s: %w", file, err)
+				}
+			}
+			candidates = append(candidates, file)
 		}
 	}
 

--- a/internal/archive/extractor.go
+++ b/internal/archive/extractor.go
@@ -181,8 +181,17 @@ func (e *BinaryExtractor) extractTarFile(reader io.Reader, targetPath string, mo
 		return fmt.Errorf("copying file content: %w", err)
 	}
 
-	// Set permissions
-	if err := os.Chmod(targetPath, os.FileMode(mode)); err != nil {
+	// Set permissions. Mask to os.ModePerm so POSIX file-type bits in the
+	// tar header (e.g. S_IFREG 0100000) don't leak into the chmod call,
+	// and ensure the executable bit is set — a tar that shipped the
+	// binary with 0644 would otherwise leave us with a non-executable
+	// file and an obscure "not executable" failure downstream in the
+	// updater's validation step.
+	perm := os.FileMode(mode) & os.ModePerm
+	if perm&0111 == 0 {
+		perm |= 0755
+	}
+	if err := os.Chmod(targetPath, perm); err != nil {
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
 
@@ -215,8 +224,15 @@ func (e *BinaryExtractor) extractZipFile(file *zip.File, targetPath string) erro
 		return fmt.Errorf("copying file content: %w", err)
 	}
 
-	// Set permissions
-	if err := os.Chmod(targetPath, file.FileInfo().Mode()); err != nil {
+	// Set permissions. ZIP mode bits are unreliable on cross-platform
+	// archives (Windows-authored zips often have mode 0 or 0644), so mask
+	// to os.ModePerm and force the executable bit — if the file is in the
+	// archive because we want to run it, we need +x regardless.
+	perm := file.FileInfo().Mode() & os.ModePerm
+	if perm&0111 == 0 {
+		perm |= 0755
+	}
+	if err := os.Chmod(targetPath, perm); err != nil {
 		return fmt.Errorf("setting file permissions: %w", err)
 	}
 

--- a/internal/archive/extractor_test.go
+++ b/internal/archive/extractor_test.go
@@ -472,3 +472,51 @@ func TestBinaryExtractor_ExtractNonExecutableTarEntry(t *testing.T) {
 	mode := info.Mode().Perm()
 	assert.NotZerof(t, mode&0o111, "extracted binary must be executable, got mode %o", mode)
 }
+
+// createTestZipWithMode builds a zip where the entry's FileInfo mode is
+// the supplied value. Windows-authored zips commonly carry mode 0 or 0644
+// for what is actually a Unix executable; this fixture reproduces that.
+func createTestZipWithMode(t *testing.T, filename string, content []byte, mode os.FileMode) string {
+	tempFile, err := os.CreateTemp("", "test-mode-*.zip")
+	require.NoError(t, err)
+	defer tempFile.Close()
+
+	zipWriter := zip.NewWriter(tempFile)
+	defer zipWriter.Close()
+
+	header := &zip.FileHeader{
+		Name:   filename,
+		Method: zip.Deflate,
+	}
+	header.SetMode(mode)
+
+	writer, err := zipWriter.CreateHeader(header)
+	require.NoError(t, err)
+	_, err = writer.Write(content)
+	require.NoError(t, err)
+
+	return tempFile.Name()
+}
+
+// TestBinaryExtractor_ExtractNonExecutableZipEntry mirrors the tar-path
+// regression for zip archives — Windows-authored zips can ship mode 0 or
+// 0644 for what is actually a Unix executable. The extractor must still
+// produce a runnable binary.
+func TestBinaryExtractor_ExtractNonExecutableZipEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+
+	archive := createTestZipWithMode(t, "pvm", createMockBinary(), 0o644)
+	defer os.Remove(archive)
+
+	extractor := NewBinaryExtractor()
+	got, err := extractor.ExtractExecutable(archive, "linux-amd64")
+	require.NoError(t, err, "extraction should succeed even when zip mode is 0644")
+	defer os.RemoveAll(filepath.Dir(got))
+
+	info, err := os.Stat(got)
+	require.NoError(t, err)
+	mode := info.Mode().Perm()
+	assert.NotZerof(t, mode&0o111, "extracted binary must be executable, got mode %o", mode)
+}

--- a/internal/archive/extractor_test.go
+++ b/internal/archive/extractor_test.go
@@ -423,3 +423,52 @@ func createMaliciousTarGz(t *testing.T) string {
 
 	return tempFile.Name()
 }
+
+// createTestTarGzWithMode builds a tar.gz where the file header carries
+// the supplied mode. Used to regression-test extraction when the archive
+// author forgot to set the executable bit.
+func createTestTarGzWithMode(t *testing.T, filename string, content []byte, mode int64) string {
+	tempFile, err := os.CreateTemp("", "test-mode-*.tar.gz")
+	require.NoError(t, err)
+	defer tempFile.Close()
+
+	gzWriter := gzip.NewWriter(tempFile)
+	defer gzWriter.Close()
+
+	tarWriter := tar.NewWriter(gzWriter)
+	defer tarWriter.Close()
+
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name: filename,
+		Size: int64(len(content)),
+		Mode: mode,
+	}))
+	_, err = tarWriter.Write(content)
+	require.NoError(t, err)
+
+	return tempFile.Name()
+}
+
+// TestBinaryExtractor_ExtractNonExecutableTarEntry is the regression test
+// for the bad-update bug that produced rc71's "binary validation failed:
+// new binary is not executable" rollback. Cross-platform packaging can
+// strip the executable bit; the extractor must defensively re-apply 0755
+// so downstream validation doesn't reject a perfectly good binary.
+func TestBinaryExtractor_ExtractNonExecutableTarEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are POSIX-only")
+	}
+
+	archive := createTestTarGzWithMode(t, "pvm", createMockBinary(), 0o644)
+	defer os.Remove(archive)
+
+	extractor := NewBinaryExtractor()
+	got, err := extractor.ExtractExecutable(archive, "linux-amd64")
+	require.NoError(t, err, "extraction should succeed even when tar mode is 0644")
+	defer os.RemoveAll(filepath.Dir(got))
+
+	info, err := os.Stat(got)
+	require.NoError(t, err)
+	mode := info.Mode().Perm()
+	assert.NotZerof(t, mode&0o111, "extracted binary must be executable, got mode %o", mode)
+}

--- a/internal/pvm/update.go
+++ b/internal/pvm/update.go
@@ -89,28 +89,40 @@ func executeUpdateCommand(cmd *cobra.Command, args []string) error {
 		Context:             cmd.Context(),
 	}
 
-	// Set up progress callback
+	// Set up progress callback. The download/replace stages fire on every
+	// HTTP read chunk (potentially 100+ per second), so only the \r-based
+	// progress bar renders inside those stages — printing `message` with
+	// a trailing \n on every tick would push the bar onto a new line each
+	// time and produce the "scrolling bars" bug. For other stages the
+	// message is printed once as a status line.
 	var lastStage updater.UpdateStage
 	opts.ProgressCallback = func(stage updater.UpdateStage, message string, progress float64) {
-		// Only print stage header when it changes
+		barStage := stage == updater.StageDownloading || stage == updater.StageReplacing
+
+		// Print stage header on transitions. Leading \n clears any
+		// in-progress bar from the previous stage.
 		if stage != lastStage {
 			cmd.Printf("\n=== %s ===\n", stage.String())
 			lastStage = stage
 		}
 
-		// Print progress with message
+		if barStage {
+			// Bar-owned stage: let showProgressBar own the line via \r.
+			// Don't print the per-tick message — that would newline and
+			// the bar would scroll instead of overwrite.
+			if progress > 0 && progress < 1.0 {
+				showProgressBar(progress, 40)
+			}
+			return
+		}
+
+		// Non-bar stage: one status line per event.
 		if message != "" {
 			if progress > 0 && progress < 1.0 {
 				cmd.Printf("%s (%.1f%%)\n", message, progress*100)
 			} else {
 				cmd.Println(message)
 			}
-		}
-
-		// Show progress bar for longer operations
-		if progress > 0 && progress < 1.0 &&
-			(stage == updater.StageDownloading || stage == updater.StageReplacing) {
-			showProgressBar(progress, 40)
 		}
 	}
 

--- a/internal/pvm/update.go
+++ b/internal/pvm/update.go
@@ -89,34 +89,25 @@ func executeUpdateCommand(cmd *cobra.Command, args []string) error {
 		Context:             cmd.Context(),
 	}
 
-	// Set up progress callback. The download/replace stages fire on every
-	// HTTP read chunk (potentially 100+ per second), so only the \r-based
-	// progress bar renders inside those stages — printing `message` with
-	// a trailing \n on every tick would push the bar onto a new line each
-	// time and produce the "scrolling bars" bug. For other stages the
-	// message is printed once as a status line.
+	// Set up progress callback. Continuous-progress stages (downloads
+	// fire on every HTTP chunk) let showProgressBar own the line via \r;
+	// the per-tick message is skipped because a trailing \n would scroll
+	// the bar. Other stages print one status line per event.
 	var lastStage updater.UpdateStage
 	opts.ProgressCallback = func(stage updater.UpdateStage, message string, progress float64) {
-		barStage := stage == updater.StageDownloading || stage == updater.StageReplacing
-
-		// Print stage header on transitions. Leading \n clears any
-		// in-progress bar from the previous stage.
+		// Stage-transition header clears any in-progress bar.
 		if stage != lastStage {
 			cmd.Printf("\n=== %s ===\n", stage.String())
 			lastStage = stage
 		}
 
-		if barStage {
-			// Bar-owned stage: let showProgressBar own the line via \r.
-			// Don't print the per-tick message — that would newline and
-			// the bar would scroll instead of overwrite.
+		if stage.HasContinuousProgress() {
 			if progress > 0 && progress < 1.0 {
 				showProgressBar(progress, 40)
 			}
 			return
 		}
 
-		// Non-bar stage: one status line per event.
 		if message != "" {
 			if progress > 0 && progress < 1.0 {
 				cmd.Printf("%s (%.1f%%)\n", message, progress*100)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"tamarou.com/pvm/internal/download"
@@ -301,6 +302,21 @@ func (u *Updater) PerformUpdate(opts *UpdateOptions) (*UpdateResult, error) {
 	// Clean up the extraction temp directory when done (no-op for direct binaries)
 	if validatedBinaryPath != downloadResult.Path {
 		defer os.RemoveAll(filepath.Dir(validatedBinaryPath))
+	}
+
+	// Defensive: ensure the extracted binary is executable before handing
+	// it to the replacer. Tar headers should carry 0755 for Go-built
+	// binaries, but there have been cases where mode bits get stripped
+	// during extraction (file-type bits in header.Mode, zip archives
+	// without proper mode, stricter platform chmod semantics). Without
+	// this, ReplaceBinary's validation rejects the new binary with
+	// "new binary is not executable" and triggers a full rollback — even
+	// though the binary itself is fine, just with the wrong chmod bits.
+	if runtime.GOOS != "windows" {
+		if chmodErr := os.Chmod(validatedBinaryPath, 0755); chmodErr != nil {
+			result.Message = fmt.Sprintf("Failed to set executable bit on new binary: %v", chmodErr)
+			return result, chmodErr
+		}
 	}
 
 	// Perform replacement (or simulate if dry run)

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -8,10 +8,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"tamarou.com/pvm/internal/download"
+	platformpkg "tamarou.com/pvm/internal/platform"
 	"tamarou.com/pvm/internal/version"
 )
 
@@ -106,6 +106,15 @@ const (
 	StageRollingBack
 	StageDone
 )
+
+// HasContinuousProgress reports whether this stage fires progress
+// callbacks often enough (e.g. per HTTP chunk during download) to warrant
+// an in-place \r-based progress bar instead of one status line per event.
+// Stages that fire a single callback per transition should use line-based
+// rendering so the status actually appears.
+func (s UpdateStage) HasContinuousProgress() bool {
+	return s == StageDownloading
+}
 
 func (s UpdateStage) String() string {
 	switch s {
@@ -304,19 +313,13 @@ func (u *Updater) PerformUpdate(opts *UpdateOptions) (*UpdateResult, error) {
 		defer os.RemoveAll(filepath.Dir(validatedBinaryPath))
 	}
 
-	// Defensive: ensure the extracted binary is executable before handing
-	// it to the replacer. Tar headers should carry 0755 for Go-built
-	// binaries, but there have been cases where mode bits get stripped
-	// during extraction (file-type bits in header.Mode, zip archives
-	// without proper mode, stricter platform chmod semantics). Without
-	// this, ReplaceBinary's validation rejects the new binary with
-	// "new binary is not executable" and triggers a full rollback — even
-	// though the binary itself is fine, just with the wrong chmod bits.
-	if runtime.GOOS != "windows" {
-		if chmodErr := os.Chmod(validatedBinaryPath, 0755); chmodErr != nil {
-			result.Message = fmt.Sprintf("Failed to set executable bit on new binary: %v", chmodErr)
-			return result, chmodErr
-		}
+	// Defense-in-depth: ensure +x on the extracted binary. Extraction
+	// occasionally drops the exec bit (odd tar mode bits, windows-authored
+	// zips); without this, ReplaceBinary's validation rejects the binary
+	// and triggers a rollback even though the binary itself is fine.
+	if chmodErr := platformpkg.MakeExecutable(validatedBinaryPath); chmodErr != nil {
+		result.Message = fmt.Sprintf("Failed to set executable bit on new binary: %v", chmodErr)
+		return result, chmodErr
 	}
 
 	// Perform replacement (or simulate if dry run)


### PR DESCRIPTION
Two production bugs surfaced when perigrin ran \`pvm update\` to upgrade to rc71.

## 1. \`pvm update\` fails with \"binary validation failed: new binary is not executable\"

rc71's self-update path aborts and triggers an automatic rollback because the extracted binary from the release tarball is missing the \`+x\` bit after extraction. Two layers of defense:

- **\`internal/archive/extractor.go\`**: mask \`header.Mode\` to \`os.ModePerm\` (POSIX file-type bits like \`S_IFREG 0100000\` should never reach \`os.Chmod\`), and force \`0755\` if the executable bit is absent. Same fix on the zip path — ZIP mode bits are unreliable on cross-platform archives.
- **\`internal/updater/updater.go\`**: after \`ValidateDownloadedBinaryWithVersion\` returns, defensively \`chmod 0755\` on non-Windows before handing the path to the replacer. Self-healing against any future extractor regression.

Regression test \`TestBinaryExtractor_ExtractNonExecutableTarEntry\` builds a tar.gz with \`mode = 0644\` and asserts \`ExtractExecutable\` produces a \`+x\` binary. Red without the fix, green with.

## 2. Progress bar scrolls across ~50 lines instead of updating in place

The progress callback in \`internal/pvm/update.go\` printed \`cmd.Printf(\"... (%.1f%%)\\n\", ...)\` on every HTTP read tick, *then* called \`showProgressBar\` which uses \`\\r\`. The trailing \`\\n\` advanced to a new line; \`\\r\` only returned to the start of the *new* line — so the bar scrolled instead of overwriting.

Fix: during \`StageDownloading\`/\`StageReplacing\`, let \`showProgressBar\` own the line via \`\\r\`; don't print the per-tick message. Other stages still print one status line per event.

## Test plan

- [x] \`go build ./...\` passes
- [x] \`go test ./...\` passes (38 packages, zero failures)
- [x] New regression test \`TestBinaryExtractor_ExtractNonExecutableTarEntry\` passes, confirmed red before fix
- [ ] Manual: tag a new rc, run \`pvm update\` from current rc, confirm bar renders cleanly and the upgrade completes without rollback

## Follow-ups (not in this PR)

- \`internal/updater/recovery.go:383\` has the same \`\\r\`-collides-with-\`\\n\` pattern for the recovery-download progress line. Low blast radius — only fires during emergency recovery.
- Callback throttling: the download callback currently fires per HTTP chunk with no rate-limit (100+/sec). After this fix the bar renders correctly but still wastes CPU rendering 50 paints/sec. Worth a \`time.Since(lastPaint) > 100ms\` guard in a follow-up.
- The post-release validation journey I was building when these bugs surfaced would have caught #1 in CI — work-in-progress on branch \`post-release-validation\`, will finish after this lands.