### PR TITLE
fix(resolver): fall back to PATH detection for system Perl (#448)

### DIFF
--- a/internal/perl/resolver.go
+++ b/internal/perl/resolver.go
@@ -837,9 +837,13 @@ func resolveFromUserConfig(cfg *config.Config, availableVersions []string) (*Res
 	}, nil
 }
 
-// resolveFromSystemPerl falls back to using the system Perl installation
+// resolveFromSystemPerl falls back to using the system Perl installation.
+// Prefers an explicit registry entry (Source=="system") so that
+// `pvm import-system` results stay authoritative, but falls back to runtime
+// PATH detection so users who never imported still get a working resolution
+// after `pvm use system`.
 func resolveFromSystemPerl() (*ResolvedVersion, error) {
-	// Find system perl in registry by looking for version with source="system"
+	// Prefer the registry entry when present.
 	installedVersions, err := GetInstalledVersions()
 	if err != nil {
 		return nil, err
@@ -847,7 +851,6 @@ func resolveFromSystemPerl() (*ResolvedVersion, error) {
 
 	for _, versionInfo := range installedVersions {
 		if versionInfo.Source == "system" {
-			// Found system perl in registry
 			// For system perl, InstallPath might be either the prefix directory (e.g., /usr) or the bin directory (e.g., /usr/bin)
 			var perlPath string
 			if filepath.Base(versionInfo.InstallPath) == "bin" {
@@ -873,9 +876,25 @@ func resolveFromSystemPerl() (*ResolvedVersion, error) {
 		}
 	}
 
+	// No registry entry. Detect on PATH. This is the path users hit when
+	// they run `pvm use system` without ever having run `pvm import-system`.
+	// Without this fallback, `pvm current` after `pvm use system` errors
+	// out with "Failed to resolve Perl version using any method" even
+	// though /usr/bin/perl is right there.
+	systemPerl, detectErr := DetectSystemPerl()
+	if detectErr == nil && systemPerl != nil {
+		return &ResolvedVersion{
+			Version:    systemPerl.Version,
+			Library:    "",
+			Source:     SystemPerlSource,
+			Path:       systemPerl.Path,
+			SourcePath: "",
+		}, nil
+	}
+
 	return nil, errors.NewVersionError(
 		ErrResolutionFailed,
-		"System Perl not found in registry. Run 'pvm import-system' to register it.",
+		"System Perl not found. No registry entry (run 'pvm import-system') and none detectable on PATH.",
 		nil)
 }
 

--- a/internal/perl/resolver_system_fallback_test.go
+++ b/internal/perl/resolver_system_fallback_test.go
@@ -1,0 +1,124 @@
+// ABOUTME: Tests for system-Perl fallback when no system Perl has been imported into the registry
+// ABOUTME: Reproduces the pvm use system / pvm current divergence reported in issue #448
+
+package perl
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveFromSystemPerl_FallsBackToDetection reproduces issue #448.
+// Scenario: user has at least one PVM-managed Perl installed (so the
+// auto-import block at the top of ResolveVersion does not fire), but never
+// ran `pvm import-system`, so the registry has no Source=="system" entry.
+// Then `pvm use system` clears PVM_PERL_VERSION and `pvm current` falls
+// through to resolveFromSystemPerl. Today that errors with "Run pvm
+// import-system to register it" even though DetectSystemPerl() can find
+// /usr/bin/perl on PATH. After the fix, resolveFromSystemPerl falls back
+// to DetectSystemPerl when the registry has no system entry.
+func TestResolveFromSystemPerl_FallsBackToDetection(t *testing.T) {
+	origGetInstalledVersions := GetInstalledVersions
+	origDetectSystemPerl := DetectSystemPerl
+	defer func() {
+		GetInstalledVersions = origGetInstalledVersions
+		DetectSystemPerl = origDetectSystemPerl
+	}()
+
+	// Registry has only PVM-managed Perls; no Source=="system" entry
+	// because the user never ran `pvm import-system`.
+	GetInstalledVersions = func() ([]VersionInfo, error) {
+		return []VersionInfo{
+			{
+				Version:     "5.42.0",
+				InstallPath: "/home/user/.local/share/pvm/versions/5.42.0",
+				Source:      "pvm",
+			},
+		}, nil
+	}
+
+	// DetectSystemPerl can find /usr/bin/perl regardless.
+	DetectSystemPerl = func() (*SystemPerl, error) {
+		path := "/usr/bin/perl"
+		if runtime.GOOS == "windows" {
+			path = `C:\Strawberry\perl\bin\perl.exe`
+		}
+		return &SystemPerl{
+			Path:    path,
+			Version: "5.34.1",
+		}, nil
+	}
+
+	resolved, err := resolveFromSystemPerl()
+
+	assert.NoError(t, err, "resolveFromSystemPerl must not error when DetectSystemPerl finds a Perl")
+	if !assert.NotNil(t, resolved) {
+		return
+	}
+	assert.Equal(t, "5.34.1", resolved.Version)
+	assert.Equal(t, SystemPerlSource, resolved.Source)
+}
+
+// TestResolveFromSystemPerl_RegistryEntryStillPreferred verifies the
+// existing happy path: when the registry has a Source=="system" entry,
+// it is returned and DetectSystemPerl is not consulted. This locks in
+// the prior behavior so the fallback only applies when registry has no
+// system entry.
+func TestResolveFromSystemPerl_RegistryEntryStillPreferred(t *testing.T) {
+	origGetInstalledVersions := GetInstalledVersions
+	origDetectSystemPerl := DetectSystemPerl
+	defer func() {
+		GetInstalledVersions = origGetInstalledVersions
+		DetectSystemPerl = origDetectSystemPerl
+	}()
+
+	GetInstalledVersions = func() ([]VersionInfo, error) {
+		return []VersionInfo{
+			{
+				Version:     "5.34.1",
+				InstallPath: "/usr",
+				Source:      "system",
+			},
+		}, nil
+	}
+
+	// If DetectSystemPerl is called, fail loudly — the registry entry
+	// should be preferred and detection should not run.
+	DetectSystemPerl = func() (*SystemPerl, error) {
+		t.Fatal("DetectSystemPerl must not be called when a Source=='system' registry entry exists")
+		return nil, nil
+	}
+
+	resolved, err := resolveFromSystemPerl()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, resolved)
+	assert.Equal(t, "5.34.1", resolved.Version)
+	assert.Equal(t, SystemPerlSource, resolved.Source)
+}
+
+// TestResolveFromSystemPerl_NoSystemPerlAtAll verifies the genuinely-no-Perl
+// case still errors. After the fix, the error message should mention what
+// was tried (registry + detection), not just "Run pvm import-system".
+func TestResolveFromSystemPerl_NoSystemPerlAtAll(t *testing.T) {
+	origGetInstalledVersions := GetInstalledVersions
+	origDetectSystemPerl := DetectSystemPerl
+	defer func() {
+		GetInstalledVersions = origGetInstalledVersions
+		DetectSystemPerl = origDetectSystemPerl
+	}()
+
+	GetInstalledVersions = func() ([]VersionInfo, error) {
+		return []VersionInfo{}, nil
+	}
+	DetectSystemPerl = func() (*SystemPerl, error) {
+		return nil, assert.AnError
+	}
+
+	resolved, err := resolveFromSystemPerl()
+
+	assert.Error(t, err)
+	assert.Nil(t, resolved)
+}

--- a/internal/perl/resolver_test.go
+++ b/internal/perl/resolver_test.go
@@ -192,6 +192,14 @@ func TestResolveForkIdentifierNotInRegistry(t *testing.T) {
 		AvailableVersions:   []string{"5.40.2"},
 		SkipLocal:           true,
 		SkipVersionResolved: true,
+		// SkipSystemPerl prevents the resolver's step-7 fallback from
+		// finding a real /usr/bin/perl on the test host. Without this,
+		// the env-step's "fork not found" error is swallowed and the
+		// system fallback succeeds — masking what this test is meant
+		// to assert (that an unsatisfied fork bubbles up). The
+		// fall-through behavior in the env step is a separate issue
+		// (see #456); this test is scoped to fork resolution.
+		SkipSystemPerl: true,
 	}
 
 	_, err := ResolveVersion(options)


### PR DESCRIPTION
## Summary

Fixes #448. After \`pvm use system\` clears \`PVM_PERL_VERSION\`, \`pvm current\` was failing with PVM-301 unless the user had previously run \`pvm import-system\`. The system Perl fallback at step 7 of the resolver only checked the registry; it never consulted \`DetectSystemPerl()\` even though that function exists and works.

## Root cause

\`internal/perl/resolver.go:resolveFromSystemPerl\` (line 841) iterates the registry looking for a version with \`Source == \"system\"\`. If none is found, it returns an error suggesting \`pvm import-system\`. \`DetectSystemPerl()\` in \`internal/perl/system.go\` already finds \`/usr/bin/perl\` on PATH and extracts version info, but \`resolveFromSystemPerl\` never called it.

The reproduction requires a specific combination:
- At least one PVM-managed Perl installed (so the early auto-import branch at \`resolver.go:180\` doesn't fire — that branch only runs when \`len(availableVersions) == 0\`)
- Never ran \`pvm import-system\`
- No \`.perl-version\`, no project config, no \`DefaultPerl\` in user config

The user reporting this had 6 installed PVM Perls and was in a directory with no project config.

## Fix

\`resolveFromSystemPerl\` now falls back to \`DetectSystemPerl()\` when the registry has no system entry. The registry entry is still preferred when present so \`pvm import-system\` results stay authoritative.

## Tests

- \`internal/perl/resolver_system_fallback_test.go\` (new) — three branches: fallback fires, registry entry preferred, no-Perl-anywhere still errors
- \`internal/perl/resolver_test.go:TestResolveForkIdentifierNotInRegistry\` — updated to use \`SkipSystemPerl: true\` (see follow-up below)

## Out-of-scope follow-up filed as #456

Pre-existing latent bug surfaced by this fix: \`resolveFromEnvironment\` returns errors for unsatisfiable explicit pins (e.g. \`PVM_PERL_VERSION=mycompany/myfork-5.40.2\` when the fork isn't installed), but the resolver swallows the error and falls through to step 7. Before this PR, step 7 also failed and the user got some error. After this PR, step 7 succeeds via PATH detection — so an unsatisfiable explicit pin silently falls back to system Perl with no warning.

\`TestResolveForkIdentifierNotInRegistry\` was updated to skip step 7 in the test so it keeps asserting what it intended (fork resolution failure). The underlying fall-through is filed as #456.

## Test plan

- [x] All three new tests pass (\`go test ./internal/perl/ -run TestResolveFromSystemPerl -v\`)
- [x] Existing \`TestResolveForkIdentifierNotInRegistry\` passes after the SkipSystemPerl tweak
- [x] \`make test\` passes (zero failures across full suite)
- [x] Smoke test: \`pvm current\` in a directory with no project config and no PVM_PERL_VERSION returns system Perl rather than PVM-301