### PR TITLE
fix(doctor): demote fresh-install registry warning to ✓ (#447)

### DIFF
--- a/internal/pvm/doctor.go
+++ b/internal/pvm/doctor.go
@@ -267,11 +267,13 @@ func checkRegistryIntegrity(ui *ui.Output, issues *[]string, warnings *[]string)
 			*issues = append(*issues, "Registry missing but versions directory contains installations")
 			ui.Error("Registry file missing: %s", registryPath)
 			return nil
-		} else {
-			*warnings = append(*warnings, "Registry file doesn't exist (no versions installed)")
-			ui.Warning("No registry file found, but no versions are installed")
-			return nil
 		}
+		// Fresh install: no registry, no versions. This is the expected
+		// steady state — the registry is created on first install. Show
+		// it as a positive check rather than a warning so users don't
+		// learn to ignore doctor output.
+		ui.Success("Registry will be created when you install your first Perl version")
+		return nil
 	}
 
 	// Load and validate registry

--- a/internal/pvm/doctor_registry_test.go
+++ b/internal/pvm/doctor_registry_test.go
@@ -1,0 +1,110 @@
+// ABOUTME: Tests for checkRegistryIntegrity's classification of fresh-install state
+// ABOUTME: A missing registry file with no installed versions is the expected steady state, not a warning
+
+package pvm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"tamarou.com/pvm/internal/cli/ui"
+)
+
+// quietUI returns a Quiet UI suitable for tests that don't care about live
+// output. The doctor functions take a *ui.Output for status messaging; the
+// tests assert on the issues/warnings slices instead.
+func quietUI() *ui.Output {
+	return ui.NewOutput(&ui.UIContext{
+		Writer: os.Stdout,
+		Quiet:  true,
+	})
+}
+
+// withFreshXDGDataHome runs fn with XDG_DATA_HOME pointing at an empty
+// tempdir, restoring the prior value afterward. fn receives the path that
+// xdg.GetDirs will treat as the PVM data dir (XDG_DATA_HOME/pvm) — that's
+// where registry.json and versions/ live, not at XDG_DATA_HOME itself.
+func withFreshXDGDataHome(t *testing.T, fn func(pvmDataDir string)) {
+	t.Helper()
+	root := t.TempDir()
+	prev, hadPrev := os.LookupEnv("XDG_DATA_HOME")
+	if err := os.Setenv("XDG_DATA_HOME", root); err != nil {
+		t.Fatalf("set XDG_DATA_HOME: %v", err)
+	}
+	defer func() {
+		if hadPrev {
+			_ = os.Setenv("XDG_DATA_HOME", prev)
+		} else {
+			_ = os.Unsetenv("XDG_DATA_HOME")
+		}
+	}()
+	pvmDataDir := filepath.Join(root, "pvm")
+	fn(pvmDataDir)
+}
+
+// TestCheckRegistryIntegrity_FreshInstallEmitsNoWarning is the regression
+// test for issue #447. On a fresh install (no registry file, no versions
+// directory), the doctor used to emit a warning ("Registry file doesn't
+// exist (no versions installed)") that trained users to ignore doctor
+// output. After the fix, this combination is treated as the expected
+// steady state and emits nothing into the warnings slice.
+func TestCheckRegistryIntegrity_FreshInstallEmitsNoWarning(t *testing.T) {
+	withFreshXDGDataHome(t, func(pvmDataDir string) {
+		// Sanity: on a fresh install the pvm data dir doesn't exist yet.
+		// checkRegistryIntegrity must tolerate that without erroring or
+		// warning.
+		if _, err := os.Stat(pvmDataDir); !os.IsNotExist(err) {
+			t.Fatalf("expected pvmDataDir not to exist on fresh install, got err=%v", err)
+		}
+
+		var issues, warnings []string
+		err := checkRegistryIntegrity(quietUI(), &issues, &warnings)
+		if err != nil {
+			t.Fatalf("checkRegistryIntegrity: %v", err)
+		}
+
+		if len(issues) != 0 {
+			t.Errorf("expected no issues on fresh install, got %v", issues)
+		}
+		if len(warnings) != 0 {
+			t.Errorf("expected no warnings on fresh install, got %v", warnings)
+		}
+	})
+}
+
+// TestCheckRegistryIntegrity_RegistryMissingButVersionsExistStillFlagsIssue
+// locks in the OTHER branch of the same conditional: when versions directory
+// has installations but registry.json is missing, that's a real broken state
+// and must continue to be reported as an issue (not silently dropped by an
+// over-eager fix to issue #447).
+func TestCheckRegistryIntegrity_RegistryMissingButVersionsExistStillFlagsIssue(t *testing.T) {
+	withFreshXDGDataHome(t, func(pvmDataDir string) {
+		// Create a versions directory under the pvm data dir with one fake
+		// installation directory inside it. No registry.json.
+		versionsDir := filepath.Join(pvmDataDir, "versions")
+		fakeInstall := filepath.Join(versionsDir, "5.40.0")
+		if err := os.MkdirAll(fakeInstall, 0755); err != nil {
+			t.Fatalf("mkdir fake install: %v", err)
+		}
+
+		var issues, warnings []string
+		err := checkRegistryIntegrity(quietUI(), &issues, &warnings)
+		if err != nil {
+			t.Fatalf("checkRegistryIntegrity: %v", err)
+		}
+
+		// The "registry missing but versions exist" path must still flag
+		// an issue.
+		foundIssue := false
+		for _, i := range issues {
+			if i == "Registry missing but versions directory contains installations" {
+				foundIssue = true
+				break
+			}
+		}
+		if !foundIssue {
+			t.Errorf("expected the 'Registry missing but versions directory contains installations' issue, got issues=%v warnings=%v", issues, warnings)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #447. On a fresh PVM install (no registry file, no versions directory), \`pvm self doctor\` was emitting a warning:

\`\`\`
⚠ No registry file found, but no versions are installed
…
⚠ Found 3 warning(s):
  • Registry file doesn't exist (no versions installed)
\`\`\`

That's the expected steady state — the registry is created when the user installs their first Perl version. Surfacing it as a warning trains users to ignore doctor output.

## Fix

\`internal/pvm/doctor.go\` \`checkRegistryIntegrity\`: when both registry.json and versions/ are absent, emit a positive Success message ("Registry will be created when you install your first Perl version") and add nothing to issues or warnings. The other branch — registry missing but versions directory contains installations — is a real broken state and continues to flag an issue.

## Tests

\`internal/pvm/doctor_registry_test.go\` covers both branches:
- \`TestCheckRegistryIntegrity_FreshInstallEmitsNoWarning\` — fresh install adds nothing to issues or warnings
- \`TestCheckRegistryIntegrity_RegistryMissingButVersionsExistStillFlagsIssue\` — broken state still raises an issue

## Smoke test

Before:

\`\`\`
⚠ Found 3 warning(s):
  • PVM version resolution may have issues
  • Registry file doesn't exist (no versions installed)   ← the spurious one
  • No Perl versions installed
\`\`\`

After (against a synthetic fresh \`XDG_DATA_HOME\`):

\`\`\`
✓ Registry will be created when you install your first Perl version
…
⚠ Found 2 warning(s):
  • PVM version resolution may have issues
  • No Perl versions installed
\`\`\`

The two remaining warnings are real and worth flagging — the user has no Perls installed and version resolution will fail in any context.

## Test plan

- [x] \`go test ./internal/pvm/ -run TestCheckRegistryIntegrity\` — both new tests pass
- [x] \`make test\` — full suite green, zero regressions
- [x] Manual smoke: \`XDG_DATA_HOME=/tmp/fresh-xdg pvm self doctor\` shows the new ✓ message