### PR TITLE
fix(help): render markdown bullet lists; correct workspace-health command (#451)

### DIFF
--- a/internal/cli/help_markdown_render_test.go
+++ b/internal/cli/help_markdown_render_test.go
@@ -1,0 +1,88 @@
+// ABOUTME: Tests that RenderMarkdownAsHelp surfaces all the markdown source's
+// ABOUTME: content — particularly bullet lists, which were previously dropped silently
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"tamarou.com/pvm/internal/cli/ui"
+	"tamarou.com/pvm/internal/data"
+)
+
+// renderToBuffer runs RenderMarkdownAsHelp into a bytes.Buffer-backed UI
+// so tests can assert on the rendered content.
+func renderToBuffer(t *testing.T, markdown string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	out := ui.NewOutput(&ui.UIContext{
+		Writer:    &buf,
+		ColorMode: ui.ColorNever,
+	})
+	RenderMarkdownAsHelp(markdown, out)
+	return buf.String()
+}
+
+// TestRenderMarkdownAsHelp_RendersBulletListItems is the regression test
+// for the bullet-dropping bug surfaced by issue #451. Before the fix,
+// `RenderMarkdownAsHelp` silently dropped every "- foo" line with a TODO
+// comment claiming list rendering would happen "separately" — but no
+// separate rendering existed. The "Diagnostic Commands" section of
+// troubleshooting.md was therefore invisible to users.
+func TestRenderMarkdownAsHelp_RendersBulletListItems(t *testing.T) {
+	markdown := `## Diagnostic Commands
+
+- Check overall workspace health: ` + "`pvm workspace doctor`" + `
+- View detailed workspace status: ` + "`pvm workspace status --json`"
+
+	rendered := renderToBuffer(t, markdown)
+
+	// The substantive content of each bullet should appear in the rendered
+	// output. We're not picky about formatting (color, prefix, etc.) — just
+	// that the text is present.
+	mustContain := []string{
+		"Check overall workspace health",
+		"pvm workspace doctor",
+		"View detailed workspace status",
+		"pvm workspace status --json",
+	}
+	for _, want := range mustContain {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("expected rendered output to contain %q, got:\n%s", want, rendered)
+		}
+	}
+}
+
+// TestTroubleshootingHelp_DiagnosticCommandsAreVisible is the issue-#451
+// integration test: load the actual troubleshooting.md asset, render it
+// the way `pvm help troubleshooting` does, and assert the user can see
+// every command listed in the "Diagnostic Commands" section. This catches
+// both (a) the markdown content drifting from reality and (b) the renderer
+// regressing on bullet handling.
+func TestTroubleshootingHelp_DiagnosticCommandsAreVisible(t *testing.T) {
+	markdown, err := data.GetHelpTemplate("troubleshooting")
+	if err != nil {
+		t.Fatalf("load troubleshooting.md: %v", err)
+	}
+
+	rendered := renderToBuffer(t, markdown)
+
+	// The "workspace health" line must point at `pvm workspace doctor`.
+	// Both commands exist; this one specifically checks workspace health.
+	// The drift from `pvm self doctor` (which checks PVM install, not
+	// workspace) was the original report.
+	if !strings.Contains(rendered, "Check overall workspace health") {
+		t.Errorf("rendered help is missing the 'workspace health' diagnostic line; output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "pvm workspace doctor") {
+		t.Errorf("rendered help should mention 'pvm workspace doctor' for workspace health; output:\n%s", rendered)
+	}
+
+	// "Verify Perl version resolution" should land on `pvm perl resolve`
+	// (NOT bare `pvm resolve`, which doesn't exist as a top-level command).
+	if !strings.Contains(rendered, "pvm perl resolve") {
+		t.Errorf("rendered help should mention 'pvm perl resolve'; output:\n%s", rendered)
+	}
+}

--- a/internal/cli/help_templates.go
+++ b/internal/cli/help_templates.go
@@ -75,8 +75,12 @@ func RenderMarkdownAsHelp(markdown string, output *ui.Output) {
 			// Commands
 			output.Printf("%s\n", line)
 		case strings.HasPrefix(line, "- "):
-			// List items - collect and render as list
-			continue // We'll handle list rendering separately
+			// List item — print as a bulleted line. The earlier "collect
+			// and render as list separately" plan was never implemented,
+			// so the bullets were silently dropped, hiding the
+			// "Diagnostic Commands" section of troubleshooting.md from
+			// users.
+			output.Printf("  %s\n", line)
 		case strings.HasPrefix(line, "`") && strings.HasSuffix(line, "`"):
 			// Inline code
 			output.Printf("  %s\n", line)

--- a/internal/data/help/troubleshooting.md
+++ b/internal/data/help/troubleshooting.md
@@ -27,7 +27,7 @@
 
 ## Diagnostic Commands
 
-- Check overall workspace health: `pvm self doctor`
+- Check overall workspace health: `pvm workspace doctor`
 - View detailed workspace status: `pvm workspace status --json`
 - Check dependency status: `pvm module status`
 - Verify Perl version resolution: `pvm perl resolve`


### PR DESCRIPTION
## Summary

Fixes #451. Two related bugs:

### 1. Markdown bullet lists were silently dropped

\`internal/cli/help_templates.go:RenderMarkdownAsHelp\` had this case:

\`\`\`go
case strings.HasPrefix(line, \"- \"):
    // List items - collect and render as list
    continue // We'll handle list rendering separately
\`\`\`

\"Separately\" never happened. Every \`- foo\` line in any help-template markdown was dropped on the floor. The user-visible result for \`pvm help troubleshooting\`:

\`\`\`
Diagnostic Commands

(blank — entire section invisible)
\`\`\`

The \"Diagnostic Commands\" section of \`internal/data/help/troubleshooting.md\` was therefore unreachable from the rendered help output even though the markdown source had four bulleted entries.

### 2. The 'workspace health' line pointed at the wrong command

\`troubleshooting.md:30\` said \`pvm self doctor\` for \"Check overall workspace health\". \`pvm self doctor\` checks the PVM installation; \`pvm workspace doctor\` checks a project workspace (Perl version compatibility, dependency status, build system). The correct command for workspace health is \`pvm workspace doctor\`.

Fix #2 alone wouldn't have helped users since the line wasn't being rendered at all (#1). Both fixed together.

## After the fix

\`\`\`
$ pvm help troubleshooting
…
Diagnostic Commands

  - Check overall workspace health: \`pvm workspace doctor\`
  - View detailed workspace status: \`pvm workspace status --json\`
  - Check dependency status: \`pvm module status\`
  - Verify Perl version resolution: \`pvm perl resolve\`
\`\`\`

## Tests

\`internal/cli/help_markdown_render_test.go\` — two tests:
- \`TestRenderMarkdownAsHelp_RendersBulletListItems\` — minimal unit test, asserts bullet content lands in rendered output (catches the rendering bug).
- \`TestTroubleshootingHelp_DiagnosticCommandsAreVisible\` — integration test, loads the actual \`troubleshooting.md\` asset and asserts the diagnostic-command content is visible after rendering. Catches both the rendering bug AND any future drift between the markdown asset and what it should say.

## Out-of-scope follow-up

#459 — \`internal/cli/help.go\` contains an unreachable parallel implementation (\`CreateHelpCommand\` plus five \`show*Help\` functions, ~280 lines). Filed for separate cleanup.

## Test plan

- [x] \`go test ./internal/cli/ -run \"TestRenderMarkdownAsHelp|TestTroubleshootingHelp\"\` passes
- [x] \`make test\` — full suite green, zero regressions
- [x] Manual smoke: \`pvm help troubleshooting\` shows the full Diagnostic Commands section with the correct \`pvm workspace doctor\` command