### PR TITLE
fix(cli): sanitize attacker-influenceable bytes before terminal output (#455)

### DIFF
--- a/internal/cli/error.go
+++ b/internal/cli/error.go
@@ -351,6 +351,33 @@ func FormatError(err error) string {
 	return formatter.Format(err)
 }
 
+// sanitizeForTerminal strips control bytes from s so attacker-influenceable
+// input (e.g. PATH directory names that flow into "detected_conflicts")
+// cannot inject ANSI escape sequences, overwrite output via \r, or fake
+// extra lines via \n. Tabs (0x09) and newlines (0x0a) are stripped along
+// with the rest because we apply this to single-line VALUES — the
+// surrounding format strings provide their own line breaks. Each stripped
+// byte is replaced with '?' so the user sees that something was removed
+// rather than getting silently truncated content.
+func sanitizeForTerminal(s string) string {
+	return strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return '?'
+		}
+		return r
+	}, s)
+}
+
+// sanitizeStrings applies sanitizeForTerminal to every element of in,
+// returning a new slice (in is not mutated).
+func sanitizeStrings(in []string) []string {
+	out := make([]string, len(in))
+	for i, s := range in {
+		out[i] = sanitizeForTerminal(s)
+	}
+	return out
+}
+
 // DisplayEnhancedError displays an enhanced error using the provided UI output
 // This is used by commands that want to show detailed error information
 func DisplayEnhancedError(output *ui.Output, err *errors.EnhancedError) {
@@ -371,26 +398,35 @@ func DisplayEnhancedError(output *ui.Output, err *errors.EnhancedError) {
 	// Display context information if available. Printf does not append a
 	// trailing newline, so each line-oriented field needs an explicit \n;
 	// otherwise they collapse into a single line of output.
+	//
+	// Every value sourced from context is sanitized before printing —
+	// some context values (notably "detected_conflicts", which is built
+	// from PATH directory names) carry attacker-influenceable bytes.
+	// Without sanitization a malicious PATH entry could inject ANSI
+	// escape codes, overwrite output via \r, or fake fresh lines via \n.
 	if context := err.Context(); len(context) > 0 {
 		if cmdName, ok := context["command"].(string); ok {
-			output.Printf("Command: %s\n", cmdName)
+			output.Printf("Command: %s\n", sanitizeForTerminal(cmdName))
 		}
 		if desc, ok := context["description"].(string); ok {
-			output.Printf("Issue: %s\n", desc)
+			output.Printf("Issue: %s\n", sanitizeForTerminal(desc))
 		}
 		if shell, ok := context["detected_shell"].(string); ok {
-			output.Printf("Detected shell: %s\n", shell)
+			output.Printf("Detected shell: %s\n", sanitizeForTerminal(shell))
 		}
 		if conflicts, ok := context["detected_conflicts"].([]string); ok && len(conflicts) > 0 {
-			output.Printf("Conflicting version managers: %v\n", conflicts)
+			output.Printf("Conflicting version managers: %v\n", sanitizeStrings(conflicts))
 		}
 		output.Println()
 	}
 
-	// Display recovery actions with clear formatting
+	// Display recovery actions with clear formatting. Recovery actions can
+	// interpolate paths derived from $HOME (via WithRecoveryAction +
+	// fmt.Sprintf), so the same sanitation applies.
 	if actions := err.RecoveryActions(); len(actions) > 0 {
 		output.Info("To fix this issue:")
 		for i, action := range actions {
+			action = sanitizeForTerminal(action)
 			// Skip numbered actions for examples
 			if strings.HasPrefix(action, "Examples") {
 				output.Println()
@@ -411,7 +447,7 @@ func DisplayEnhancedError(output *ui.Output, err *errors.EnhancedError) {
 
 	// Display hint if available
 	if hint := err.Hint(); hint != "" {
-		output.Info("Hint: %s", hint)
+		output.Info("Hint: %s", sanitizeForTerminal(hint))
 		output.Println()
 	}
 }

--- a/internal/cli/error_display_sanitize_test.go
+++ b/internal/cli/error_display_sanitize_test.go
@@ -1,0 +1,164 @@
+// ABOUTME: Tests for terminal-output sanitization in DisplayEnhancedError
+// ABOUTME: Ensures attacker-influenceable bytes (PATH entries, env vars) cannot inject ANSI escapes or fake lines
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"tamarou.com/pvm/internal/errors"
+)
+
+// TestDisplayEnhancedError_SanitizesContextValuesWithControlBytes is the
+// regression test for issue #455. A malicious PATH entry (or any context
+// value derived from environment input) could contain ANSI escape codes,
+// newlines, or control bytes; %v formatting forwards them verbatim to
+// the terminal. After the fix, control bytes in context values should
+// be rendered escaped or stripped, never interpreted by the terminal.
+func TestDisplayEnhancedError_SanitizesContextValuesWithControlBytes(t *testing.T) {
+	cases := []struct {
+		name      string
+		conflicts []string
+	}{
+		{
+			name: "ANSI clear-screen escape in PATH entry",
+			// \033[2J = clear screen, \033[H = cursor home — a malicious
+			// PATH entry could blank PVM's output and reposition the
+			// cursor before injecting fake text.
+			conflicts: []string{"plenv (\x1b[2J\x1b[H/tmp/evil)"},
+		},
+		{
+			name: "embedded newline in PATH entry",
+			// A newline in a PATH entry would let the attacker inject a
+			// new line of fake output that looks like PVM said it.
+			conflicts: []string{"plenv (/tmp/evil\nFake PVM message: success)"},
+		},
+		{
+			name: "carriage-return-based overwrite",
+			// \r alone moves the cursor to column 0 without advancing —
+			// next characters overwrite the existing line.
+			conflicts: []string{"plenv (/tmp/evil\rOVERWRITTEN)"},
+		},
+		{
+			name: "NUL byte truncation attempt",
+			// Some terminals stop at NUL; attacker could hide content.
+			conflicts: []string{"plenv (/tmp/before\x00hidden-after)"},
+		},
+		{
+			name:      "DEL character (0x7f)",
+			conflicts: []string{"plenv (/tmp/evil\x7f)"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			out := newTestUI(&stdout, &stderr)
+
+			shellErr := errors.NewShellIntegrationError(
+				errors.ErrShellVersionManagerConflict,
+				"Version manager conflicts detected",
+				nil,
+				"zsh",
+			)
+			shellErr.WithContext("detected_conflicts", tc.conflicts)
+
+			DisplayEnhancedError(out, shellErr.EnhancedError)
+
+			combined := stdout.String() + stderr.String()
+			assertNoUnescapedControlBytes(t, combined)
+		})
+	}
+}
+
+// TestDisplayEnhancedError_NewlineInValueDoesNotInjectExtraLine asserts
+// that a newline embedded in a context value does not inject a fresh
+// line of output that could mimic PVM's own messages. Counted by line
+// number — a single conflict entry should occupy one line, regardless
+// of newlines inside its content.
+func TestDisplayEnhancedError_NewlineInValueDoesNotInjectExtraLine(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	out := newTestUI(&stdout, &stderr)
+
+	shellErr := errors.NewShellIntegrationError(
+		errors.ErrShellVersionManagerConflict,
+		"Version manager conflicts detected",
+		nil,
+		"zsh",
+	)
+	// Embedded newline tries to make this look like two separate items.
+	shellErr.WithContext("detected_conflicts", []string{"plenv (/tmp/evil\nFake PVM message: success)"})
+
+	DisplayEnhancedError(out, shellErr.EnhancedError)
+
+	combined := stdout.String() + stderr.String()
+	// "Fake PVM message" must not appear at the start of any rendered
+	// line. If it does, an embedded newline broke out of its container
+	// and the user sees what looks like PVM's own output.
+	for _, line := range strings.Split(combined, "\n") {
+		trimmed := strings.TrimLeft(line, " \t]")
+		if strings.HasPrefix(trimmed, "Fake PVM message") {
+			t.Errorf("attacker-controlled newline injected a standalone line; output:\n%s", combined)
+		}
+	}
+}
+
+// TestDisplayEnhancedError_SanitizesRecoveryActionsWithControlBytes covers
+// the other side: recovery actions interpolate paths derived from $HOME
+// (e.g. "Add 'eval ...' to ~/.zshrc"). If HOME contains control bytes,
+// they reach the terminal through the recovery-action string. Same policy.
+func TestDisplayEnhancedError_SanitizesRecoveryActionsWithControlBytes(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	out := newTestUI(&stdout, &stderr)
+
+	shellErr := errors.NewMissingShellIntegrationError("zsh")
+	shellErr.WithRecoveryAction("Create config file: touch /home/\x1b[31mevil\x1b[0m/.zshrc")
+
+	DisplayEnhancedError(out, shellErr.EnhancedError)
+
+	combined := stdout.String() + stderr.String()
+	assertNoUnescapedControlBytes(t, combined)
+}
+
+// TestDisplayEnhancedError_PreservesLegitimateContent ensures the
+// sanitizer doesn't break normal output: tabs and newlines remain valid
+// (the renderer relies on \n for line breaks), printable ASCII passes
+// through, and Unicode characters (e.g. the ✓ glyph in Success messages)
+// are not mangled.
+func TestDisplayEnhancedError_PreservesLegitimateContent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	out := newTestUI(&stdout, &stderr)
+
+	DisplayEnhancedError(out, makeMissingShellIntegrationError())
+
+	combined := stdout.String() + stderr.String()
+
+	// Ordinary content from makeMissingShellIntegrationError must survive.
+	for _, want := range []string{"Command: use", "Detected shell: zsh", "Examples after setup:"} {
+		if !strings.Contains(combined, want) {
+			t.Errorf("expected sanitization to preserve %q, got:\n%s", want, combined)
+		}
+	}
+}
+
+// assertNoUnescapedControlBytes scans s for raw control bytes that should
+// have been stripped or escaped by the sanitizer. Permits \n (line
+// separator the renderer relies on) and \t (tab) since they're benign
+// for terminal display. ESC (0x1b) is the most dangerous one — it's the
+// lead byte for ANSI escape sequences. Color codes from the rendering
+// library itself stay because tests use ColorNever.
+func assertNoUnescapedControlBytes(t *testing.T, s string) {
+	t.Helper()
+	for i, r := range s {
+		switch r {
+		case '\n', '\t':
+			continue
+		}
+		if r < 0x20 || r == 0x7f {
+			t.Errorf("control byte %#x found at offset %d in rendered output:\n%q", r, i, s)
+			return
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #455. \`DisplayEnhancedError\` forwarded context values straight to the terminal via \`Printf %s\` / \`%v\`, including \`detected_conflicts\` — a \`[]string\` built from PATH directory names. PATH entries can carry arbitrary bytes (ANSI escape codes, carriage returns, NUL, DEL, and newlines that could fake fresh PVM lines).

## Threat model

- **Direct:** \`detected_conflicts\` populated from \`detectVersionManagerConflicts(PATH)\`. A malicious PATH entry like \`/tmp/evil\\x1b[2J\\x1b[H\` could blank the terminal and reposition the cursor before the user reads PVM's output.
- **Indirect:** recovery actions interpolate paths derived from \$HOME (e.g. \"Add 'eval ...' to ~/.zshrc\"). Same vector if HOME is malicious.

The vector is **latent** today: \`detected_conflicts\` is only set by \`addConflictGuidance\` (PVM-604), and nothing in the runtime currently raises that error code. But the field is built on every \`ShellIntegrationError\` construction, the renderer is exported, and the surface keeps growing. Fixing at the render boundary covers all three sources.

## Fix

A small \`sanitizeForTerminal\` helper that replaces every control byte (< 0x20 or 0x7f) with \`?\`. Applied uniformly to:
- context values (\`command\`, \`description\`, \`detected_shell\`, \`detected_conflicts\`)
- recovery actions
- hint text

Newlines and tabs are stripped along with the rest because the sanitizer runs on single-line **values** — surrounding format strings provide their own line breaks.

## Tests

\`internal/cli/error_display_sanitize_test.go\`:
- \`TestDisplayEnhancedError_SanitizesContextValuesWithControlBytes\` — five subtests for the byte classes the issue calls out (ANSI escape, embedded newline, carriage return, NUL, DEL)
- \`TestDisplayEnhancedError_NewlineInValueDoesNotInjectExtraLine\` — asserts attacker can't inject a fake \"PVM said\" line via embedded \\n
- \`TestDisplayEnhancedError_SanitizesRecoveryActionsWithControlBytes\` — covers the recovery-action vector
- \`TestDisplayEnhancedError_PreservesLegitimateContent\` — ensures normal output (Command:, Detected shell:, Examples:) still renders

## Test plan

- [x] All sanitization tests pass; pre-existing tests still pass (no regression)
- [x] \`make test\` — full suite green, zero failures
- [x] No public API changes; \`sanitizeForTerminal\` is unexported